### PR TITLE
Fix cron timezone, captain validation window, and submit date

### DIFF
--- a/src/app/(app)/leagues/[id]/submit/page.tsx
+++ b/src/app/(app)/leagues/[id]/submit/page.tsx
@@ -1302,21 +1302,7 @@ export default function SubmitActivityPage({
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div className="space-y-2">
                   <Label>Activity Date</Label>
-                  <p className="text-xs text-muted-foreground">Only today or yesterday can be selected.</p>
-                  <Select
-                    value={isTodaySelected ? 'today' : 'yesterday'}
-                    onValueChange={(value) =>
-                      setActivityDate(value === 'today' ? today : yesterday)
-                    }
-                  >
-                    <SelectTrigger className="w-full">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="today">Today ({format(today, 'MMM d, yyyy')})</SelectItem>
-                      <SelectItem value="yesterday">Yesterday ({format(yesterday, 'MMM d, yyyy')})</SelectItem>
-                    </SelectContent>
-                  </Select>
+                  <p className="text-xs text-muted-foreground">Today ({format(today, 'MMM d, yyyy')})</p>
                 </div>
               </div>
 

--- a/src/app/api/submissions/[id]/validate/route.ts
+++ b/src/app/api/submissions/[id]/validate/route.ts
@@ -143,22 +143,6 @@ export async function POST(
       );
     }
 
-    // Captains have a 2-day window to approve/reject workout submissions
-    if (isCaptainOfTeam && !canOverride && submission.type === 'workout') {
-      const createdAt = submission.created_date ? new Date(submission.created_date) : null;
-      if (createdAt && Number.isFinite(createdAt.getTime())) {
-        const now = Date.now();
-        const ageMs = now - createdAt.getTime();
-        const twoDaysMs = 2 * 24 * 60 * 60 * 1000;
-        if (ageMs > twoDaysMs) {
-          return NextResponse.json(
-            { error: 'Captains can only validate workouts within 2 days of submission' },
-            { status: 403 }
-          );
-        }
-      }
-    }
-
     // Captains can override their team's submissions (including their own)
     // Hosts/Governors can override any submission
     // Note: Removed the restriction that prevented captains from overriding already graded submissions

--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,7 @@
     },
     {
       "path": "/api/cron/auto-rest-day",
-      "schedule": "0 11 * * *"
+      "schedule": "30 10 * * *"
     },
     {
       "path": "/api/cron/cleanup-abandoned-payments",


### PR DESCRIPTION
## Summary
- **Cron timezone fix**: Schedule changed from 11:00 UTC to 10:30 UTC (4:00 PM IST). Timezone offset corrected from UTC (0) to IST (5.5) so "yesterday" is calculated correctly for auto rest day assignment.
- **Captain validation**: Removed 2-day restriction — captains can now approve/reject workouts anytime.
- **Submit page**: Removed "Yesterday" date option. Players can only submit for today (yesterday only allowed for reuploads of rejected entries).

## DB fixes already applied
- RFL league status updated from "scheduled" → "active"
- 79 missing rest day entries backfilled (Feb 16-25) — all 55 members now have 1 entry per day
- Backup saved locally as `rfl-backup-before-backfill.json`

## Files Changed
- `vercel.json` — cron schedule update
- `src/app/api/cron/auto-rest-day/route.ts` — IST timezone offset + updated comments
- `src/app/api/submissions/[id]/validate/route.ts` — removed captain 2-day window
- `src/app/(app)/leagues/[id]/submit/page.tsx` — removed yesterday date option

## Test plan
- [ ] Verify cron fires at 4:00 PM IST and assigns rest days correctly
- [ ] Captain can reject a workout older than 2 days
- [ ] Submit page only shows "Today" date
- [ ] Leaderboard shows equal normalized points for all teams after backfill