### PR TITLE
Fix leaderboard RR tiebreaker + team name editing

### DIFF
--- a/src/hooks/use-league-leaderboard.ts
+++ b/src/hooks/use-league-leaderboard.ts
@@ -253,8 +253,11 @@ export function useLeagueLeaderboard(
               total_points: displayTotal, // overwrite displayed total to normalized base + challenge bonus
             };
           });
-          // Sort by normalized display total and reassign ranks
-          normalizedTeams.sort((a, b) => b.total_points - a.total_points);
+          // Sort by normalized display total, then avg_rr DESC as tiebreaker
+          normalizedTeams.sort((a, b) => {
+            if (b.total_points !== a.total_points) return b.total_points - a.total_points;
+            return b.avg_rr - a.avg_rr;
+          });
           const reRanked = normalizedTeams.map((t, idx) => ({ ...t, rank: idx + 1 }));
 
           // Normalize pending window (today/yesterday) pointsByDate using team member counts


### PR DESCRIPTION
## Summary
- **Leaderboard fix**: When teams have equal normalized points, they are now ranked by RR (higher RR = higher rank). The backend already had this tiebreaker but client-side normalization sort was missing it.
- **Team name editing**: Hosts/governors can now rename teams post-setup via "Edit Name" in the team dropdown menu.

## Test plan
- [ ] Open leaderboard with normalized view — teams with equal points should be sorted by RR descending
- [ ] As host, go to Team Management → click team dropdown → "Edit Name" → change name → verify it updates