### PR TITLE
Remove search/pagination, add RR, improve league home UX

### DIFF
--- a/src/app/(app)/leagues/[id]/leaderboard/page.tsx
+++ b/src/app/(app)/leagues/[id]/leaderboard/page.tsx
@@ -470,7 +470,7 @@ export default function LeaderboardPage({ params }: { params: Promise<{ id: stri
         <div className="rounded-lg border bg-card shadow-sm p-3 sm:p-4">
           <div className="mb-3">
             <h2 className="text-base sm:text-lg font-semibold">Individual Rankings</h2>
-            <p className="text-xs sm:text-sm text-muted-foreground">Top 20% performers</p>
+            <p className="text-xs sm:text-sm text-muted-foreground">Top performers</p>
           </div>
           <div className="overflow-hidden">
             <LeagueIndividualsTable individuals={individuals} showAvgRR={true} />

--- a/src/app/(app)/leagues/[id]/page.tsx
+++ b/src/app/(app)/leagues/[id]/page.tsx
@@ -440,7 +440,7 @@ export default function LeagueDashboardPage({
           rows.push({ date: ymd, label, subtitle, status: statusLabel, pointsLabel, submission: entry });
         }
 
-        if (!cancelled) setRecentDays(rows);
+        if (!cancelled) setRecentDays(rows.reverse());
       } catch {
         if (!cancelled) setRecentDays([]);
       }
@@ -1026,7 +1026,7 @@ export default function LeagueDashboardPage({
                       {mySummary?.points.toLocaleString() ?? '—'}
                     </div>
                   </div>
-                  <div className="rounded-md border border-border/60 bg-muted/40 px-3 py-2.5 text-center">
+                  <div className="rounded-md border border-primary/20 bg-primary/10 dark:bg-primary/20 px-3 py-2.5 text-center">
                     <div className="text-xs text-muted-foreground">Avg RR</div>
                     <div className="text-base font-semibold text-foreground tabular-nums">
                       {mySummary?.avgRR !== null && typeof mySummary?.avgRR === 'number'
@@ -1045,7 +1045,9 @@ export default function LeagueDashboardPage({
                   <div className="rounded-md border border-border/60 bg-muted/40 px-3 py-2.5 text-center">
                     <div className="text-[11px] text-muted-foreground">Rest Days Remaining</div>
                     <div className="text-sm font-semibold text-foreground tabular-nums">
-                      {mySummary?.restUnused !== null && typeof mySummary?.restUnused === 'number' ? mySummary.restUnused.toLocaleString() : '—'}
+                      {mySummary?.restUnused !== null && typeof mySummary?.restUnused === 'number'
+                        ? `${mySummary.restUnused} (of ${league.rest_days})`
+                        : '—'}
                     </div>
                   </div>
                 </div>
@@ -1413,6 +1415,10 @@ export default function LeagueDashboardPage({
                 <span className="text-muted-foreground">
                   <span className="font-semibold text-foreground">{daysRemaining}</span> days remaining
                 </span>
+              </div>
+              <div className="flex justify-between mt-2 text-xs text-muted-foreground">
+                <span>{formatDate(league.start_date)} — {formatDate(league.end_date)}</span>
+                <span><span className="font-semibold text-foreground">{league.league_capacity || 0}</span> players</span>
               </div>
             </CardContent>
           </Card>

--- a/src/app/(app)/leagues/[id]/team/page.tsx
+++ b/src/app/(app)/leagues/[id]/team/page.tsx
@@ -110,6 +110,11 @@ function TeamMemberView({
           }
         }
 
+        // Sort by points DESC, then RR DESC
+        membersWithPoints.sort((a: any, b: any) => {
+          if (b.points !== a.points) return b.points - a.points;
+          return (b.avg_rr || 0) - (a.avg_rr || 0);
+        });
         setMembers(membersWithPoints);
       } catch (err) {
         console.error(err);

--- a/src/components/leaderboard/league-individuals-table.tsx
+++ b/src/components/leaderboard/league-individuals-table.tsx
@@ -1,44 +1,17 @@
 /**
  * League Individuals Table
- * DataTable component for displaying individual player rankings in the leaderboard.
+ * Simple table for displaying top individual player rankings.
  */
 'use client';
 
 import * as React from 'react';
 import {
-  flexRender,
-  getCoreRowModel,
-  getFilteredRowModel,
-  getPaginationRowModel,
-  getSortedRowModel,
-  useReactTable,
-  type ColumnDef,
-  type SortingState,
-} from '@tanstack/react-table';
-import {
   Trophy,
-  User,
   Star,
   Medal,
-  ChevronLeft,
-  ChevronRight,
-  ChevronsLeft,
-  ChevronsRight,
-  Search,
 } from 'lucide-react';
 
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
 import {
   Table,
   TableBody,
@@ -93,235 +66,81 @@ export function LeagueIndividualsTable({
   individuals: IndividualRanking[];
   showAvgRR?: boolean;
 }) {
-  const [sorting, setSorting] = React.useState<SortingState>([]);
-  const [globalFilter, setGlobalFilter] = React.useState('');
-  const [pagination, setPagination] = React.useState({
-    pageIndex: 0,
-    pageSize: 10,
-  });
-
-  const columns = React.useMemo<ColumnDef<IndividualRanking>[]>(() => [
-    {
-      accessorKey: 'rank',
-      header: 'Rank',
-      cell: ({ row }) => <RankBadge rank={row.original.rank} />,
-    },
-    {
-      accessorKey: 'username',
-      header: 'Player',
-      cell: ({ row }) => {
-        const getInitials = (name: string) => {
-          if (!name) return 'U';
-          const parts = name.split(' ');
-          if (parts.length >= 2) {
-            return `${parts[0][0]}${parts[1][0]}`.toUpperCase();
-          }
-          return name.substring(0, 2).toUpperCase();
-        };
-
-        return (
-          <div className="flex items-center gap-2">
-            <Avatar className="size-8 shrink-0">
-              <AvatarImage src={(row.original as any).profile_picture_url || undefined} />
-              <AvatarFallback className="text-xs bg-primary/10 text-primary">
-                {getInitials(row.original.username)}
-              </AvatarFallback>
-            </Avatar>
-            <div>
-              <p className="font-semibold text-sm whitespace-nowrap">{row.original.username}</p>
-              {row.original.team_name && (
-                <p className="text-xs text-muted-foreground whitespace-nowrap">
-                  {row.original.team_name}
-                </p>
-              )}
-            </div>
-          </div>
-        );
-      },
-    },
-    {
-      accessorKey: 'points',
-      header: 'Points',
-      cell: ({ row }) => {
-        // Individual players only have activity points - challenge points go to team only
-        return (
-          <div className="text-base font-bold text-primary tabular-nums">
-            {row.original.points}
-          </div>
-        );
-      },
-    },
-    ...(showAvgRR
-      ? [
-        {
-          accessorKey: 'avg_rr',
-          header: 'RR',
-          cell: ({ row }) => (
-            <div className="flex items-center gap-1">
-              <Star className="size-3.5 text-yellow-500" />
-              <span className="text-sm font-medium whitespace-nowrap">
-                {row.original.avg_rr.toFixed(2)}
-              </span>
-            </div>
-          ),
-        },
-      ]
-      : []),
-  ], [showAvgRR]);
-
-  const table = useReactTable({
-    data: individuals,
-    columns,
-    state: { sorting, globalFilter, pagination },
-    onSortingChange: setSorting,
-    onGlobalFilterChange: setGlobalFilter,
-    onPaginationChange: setPagination,
-    getCoreRowModel: getCoreRowModel(),
-    getFilteredRowModel: getFilteredRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-  });
-
-  const totalRows = table.getFilteredRowModel().rows.length;
-  const pageCount = table.getPageCount() || 1;
+  const getInitials = (name: string) => {
+    if (!name) return 'U';
+    const parts = name.split(' ');
+    if (parts.length >= 2) {
+      return `${parts[0][0]}${parts[1][0]}`.toUpperCase();
+    }
+    return name.substring(0, 2).toUpperCase();
+  };
 
   return (
-    <div className="space-y-4">
-      {/* Search */}
-      <div className="relative max-w-xs">
-        <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-        <Input
-          placeholder="Search players..."
-          value={globalFilter}
-          onChange={(e) => setGlobalFilter(e.target.value)}
-          className="pl-9"
-        />
-      </div>
+    <div className="rounded-lg border overflow-x-auto">
+      <Table className="w-full">
+        <TableHeader>
+          <TableRow>
+            <TableHead>Rank</TableHead>
+            <TableHead>Player</TableHead>
+            <TableHead>Points</TableHead>
+            {showAvgRR && <TableHead>RR</TableHead>}
+          </TableRow>
+        </TableHeader>
 
-      {/* Table */}
-      <div className="rounded-lg border overflow-x-auto">
-        <Table className="w-full">
-          <TableHeader>
-            {table.getHeaderGroups().map((hg) => (
-              <TableRow key={hg.id}>
-                {hg.headers.map((header) => (
-                  <TableHead key={header.id}>
-                    {flexRender(header.column.columnDef.header, header.getContext())}
-                  </TableHead>
-                ))}
-              </TableRow>
-            ))}
-          </TableHeader>
-
-          <TableBody>
-            {table.getRowModel().rows.length ? (
-              table.getRowModel().rows.map((row) => (
-                <TableRow
-                  key={row.id}
-                  className={cn(row.original.rank <= 3 && 'bg-muted/30')}
-                >
-                  {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id}>
-                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                    </TableCell>
-                  ))}
-                </TableRow>
-              ))
-            ) : (
-              <TableRow>
-                <TableCell colSpan={columns.length} className="h-24 text-center">
-                  No players found
+        <TableBody>
+          {individuals.length ? (
+            individuals.map((player) => (
+              <TableRow
+                key={player.user_id}
+                className={cn(player.rank <= 3 && 'bg-muted/30')}
+              >
+                <TableCell>
+                  <RankBadge rank={player.rank} />
                 </TableCell>
+                <TableCell>
+                  <div className="flex items-center gap-2">
+                    <Avatar className="size-8 shrink-0">
+                      <AvatarImage src={(player as any).profile_picture_url || undefined} />
+                      <AvatarFallback className="text-xs bg-primary/10 text-primary">
+                        {getInitials(player.username)}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div>
+                      <p className="font-semibold text-sm whitespace-nowrap">{player.username}</p>
+                      {player.team_name && (
+                        <p className="text-xs text-muted-foreground whitespace-nowrap">
+                          {player.team_name}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <div className="text-base font-bold text-primary tabular-nums">
+                    {player.points}
+                  </div>
+                </TableCell>
+                {showAvgRR && (
+                  <TableCell>
+                    <div className="flex items-center gap-1">
+                      <Star className="size-3.5 text-yellow-500" />
+                      <span className="text-sm font-medium whitespace-nowrap">
+                        {player.avg_rr.toFixed(2)}
+                      </span>
+                    </div>
+                  </TableCell>
+                )}
               </TableRow>
-            )}
-          </TableBody>
-        </Table>
-
-        {/* Pagination */}
-        {totalRows > 0 && (
-          <div className="border-t px-4 py-4 space-y-3">
-
-            {/* Top count (centered) */}
-            <div className="text-center text-sm text-muted-foreground">
-              {totalRows} player{totalRows === 1 ? '' : 's'}
-            </div>
-
-            {/* Controls row */}
-            <div className="flex items-center justify-center gap-6 flex-wrap">
-
-              {/* Rows per page */}
-              <div className="flex items-center gap-2">
-                <span className="text-sm text-muted-foreground">Rows</span>
-                <Select
-                  value={String(pagination.pageSize)}
-                  onValueChange={(value) =>
-                    setPagination({ pageIndex: 0, pageSize: Number(value) })
-                  }
-                >
-                  <SelectTrigger className="h-9 w-[72px]">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {[10, 20, 50].map((size) => (
-                      <SelectItem key={size} value={String(size)}>
-                        {size}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-
-              {/* Page info */}
-              <div className="text-sm font-medium">
-                Page {pagination.pageIndex + 1} / {pageCount}
-              </div>
-
-              {/* Navigation */}
-              <div className="flex items-center gap-1">
-                <Button
-                  variant="outline"
-                  size="icon"
-                  className="h-9 w-9 rounded-full"
-                  onClick={() => table.setPageIndex(0)}
-                  disabled={!table.getCanPreviousPage()}
-                >
-                  <ChevronsLeft className="size-4" />
-                </Button>
-
-                <Button
-                  variant="outline"
-                  size="icon"
-                  className="h-9 w-9 rounded-full"
-                  onClick={() => table.previousPage()}
-                  disabled={!table.getCanPreviousPage()}
-                >
-                  <ChevronLeft className="size-4" />
-                </Button>
-
-                <Button
-                  variant="outline"
-                  size="icon"
-                  className="h-9 w-9 rounded-full"
-                  onClick={() => table.nextPage()}
-                  disabled={!table.getCanNextPage()}
-                >
-                  <ChevronRight className="size-4" />
-                </Button>
-
-                <Button
-                  variant="outline"
-                  size="icon"
-                  className="h-9 w-9 rounded-full"
-                  onClick={() => table.setPageIndex(pageCount - 1)}
-                  disabled={!table.getCanNextPage()}
-                >
-                  <ChevronsRight className="size-4" />
-                </Button>
-              </div>
-            </div>
-          </div>
-        )}
-      </div>
+            ))
+          ) : (
+            <TableRow>
+              <TableCell colSpan={showAvgRR ? 4 : 3} className="h-24 text-center">
+                No players found
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Individual rankings: removed search bar and pagination, simple flat list, subtitle "Top performers"
- Team members: removed search/pagination, all on one page, sorted by points+RR DESC, added RR column
- League Progress: added schedule dates and total players count
- My Summary: Rest Days Remaining now shows "7 (of 8)" format
- My Summary: Avg RR box highlighted like Total Points
- Activity history: reversed to latest-first order

## Test plan
- [ ] Leaderboard > Individual Rankings: no search bar, no pagination, just a clean list
- [ ] My Team: all members on one page, sorted by points then RR, RR column visible
- [ ] My Activity: League Progress shows dates + player count
- [ ] My Activity: Rest Days Remaining shows "7 (of 8)"
- [ ] My Activity: Avg RR box has highlighted background
- [ ] My Activity: weekly history shows latest day at top