### PR TITLE
Admin: host info in leagues table + Login as Host impersonation

### DIFF
--- a/src/app/(admin)/admin/layout.tsx
+++ b/src/app/(admin)/admin/layout.tsx
@@ -54,6 +54,16 @@ export default function AdminLayout({
     }
   }, [session, status, router]);
 
+  // Auto-cleanup: remove any orphaned impersonation roles when admin visits admin pages
+  useEffect(() => {
+    if (status !== "authenticated") return;
+    const userRole =
+      (session?.user as any)?.platform_role || (session?.user as any)?.role;
+    if (userRole !== "admin") return;
+
+    fetch("/api/admin/impersonate/cleanup", { method: "POST" }).catch(() => {});
+  }, [session, status]);
+
   // Loading state
   if (status === "loading") {
     return (

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { useSession } from 'next-auth/react';
 import { usePathname, useRouter } from 'next/navigation';
 
@@ -11,7 +11,7 @@ import { AppHeader } from '@/components/app/app-header';
 import { MobileBottomTabs } from '@/components/app/mobile-bottom-tabs';
 import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar';
 import { Button } from '@/components/ui/button';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, ShieldAlert, LogOut } from 'lucide-react';
 
 
 
@@ -66,6 +66,33 @@ export default function AppLayout({
     router.push(backHref);
   }, [backHref, router]);
 
+  const isAdmin = (session?.user as any)?.platform_role === 'admin';
+  const leagueMatch = pathname?.match(/^\/leagues\/([^/]+)/);
+  const impersonatingLeagueId = isAdmin && leagueMatch ? leagueMatch[1] : null;
+  const [isExiting, setIsExiting] = useState(false);
+
+  const handleExitAdminMode = useCallback(async () => {
+    if (!impersonatingLeagueId) return;
+    setIsExiting(true);
+    try {
+      await fetch(`/api/admin/leagues/${impersonatingLeagueId}/impersonate`, {
+        method: 'DELETE',
+      });
+    } catch (err) {
+      console.error('Error cleaning up impersonation:', err);
+    }
+    router.push('/admin/leagues');
+  }, [impersonatingLeagueId, router]);
+
+  // Auto-cleanup: when admin navigates away from a league page, clean up
+  useEffect(() => {
+    if (!isAdmin || !pathname) return;
+    // If admin is no longer on a league page, run cleanup for any lingering roles
+    if (!pathname.startsWith('/leagues/')) {
+      fetch('/api/admin/impersonate/cleanup', { method: 'POST' }).catch(() => {});
+    }
+  }, [isAdmin, pathname]);
+
   // Redirect unauthenticated users to login
   useEffect(() => {
     if (status === 'loading') return;
@@ -114,6 +141,29 @@ export default function AppLayout({
             {/* Page Content */}
             <main className="flex-1 overflow-auto pb-20 md:pb-0">
               <div className="p-4 lg:p-6">
+                {impersonatingLeagueId && (
+                  <div className="mb-4 flex items-center gap-3 rounded-lg border border-amber-300 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-700 px-4 py-3">
+                    <ShieldAlert className="size-5 text-amber-600 shrink-0" />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-semibold text-amber-800 dark:text-amber-300">
+                        Admin Mode — You are viewing this league as Host
+                      </p>
+                      <p className="text-xs text-amber-600 dark:text-amber-400">
+                        Your access will be removed when you leave this page.
+                      </p>
+                    </div>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="shrink-0 border-amber-300 text-amber-700 hover:bg-amber-100 dark:border-amber-600 dark:text-amber-300 dark:hover:bg-amber-900/40"
+                      onClick={handleExitAdminMode}
+                      disabled={isExiting}
+                    >
+                      <LogOut className="size-4 mr-1" />
+                      {isExiting ? 'Exiting...' : 'Exit Admin Mode'}
+                    </Button>
+                  </div>
+                )}
                 {pathname !== '/dashboard'
                   && !/^\/leagues\/[^/]+$/.test(pathname || '')
                   && !/^\/leagues\/[^/]+\/submit$/.test(pathname || '')

--- a/src/app/api/admin/impersonate/cleanup/route.ts
+++ b/src/app/api/admin/impersonate/cleanup/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth/config';
+import { getSupabaseServiceRole } from '@/lib/supabase/client';
+
+/**
+ * POST /api/admin/impersonate/cleanup
+ * Removes all temporary league memberships and roles for the admin user.
+ * Called on admin layout mount to clean up any orphaned impersonation state.
+ */
+export async function POST(req: NextRequest) {
+  try {
+    const session = (await getServerSession(authOptions as any)) as import('next-auth').Session | null;
+    if (!session?.user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const userRole = (session.user as any)?.platform_role;
+    if (userRole !== 'admin') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const adminUserId = (session.user as any)?.id;
+    const supabase = getSupabaseServiceRole();
+
+    // Remove all role assignments for this admin user across all leagues
+    const { error: rolesError } = await supabase
+      .from('assignedrolesforleague')
+      .delete()
+      .eq('user_id', adminUserId);
+
+    if (rolesError) {
+      console.error('Error cleaning up admin roles:', rolesError);
+    }
+
+    // Remove all league memberships for this admin user
+    const { error: membersError } = await supabase
+      .from('leaguemembers')
+      .delete()
+      .eq('user_id', adminUserId);
+
+    if (membersError) {
+      console.error('Error cleaning up admin memberships:', membersError);
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error in impersonate cleanup:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/leagues/[leagueId]/impersonate/route.ts
+++ b/src/app/api/admin/leagues/[leagueId]/impersonate/route.ts
@@ -1,0 +1,144 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth/config';
+import { getSupabaseServiceRole } from '@/lib/supabase/client';
+
+/**
+ * POST /api/admin/leagues/[leagueId]/impersonate
+ * Temporarily grants the admin user host access to a league.
+ */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ leagueId: string }> }
+) {
+  try {
+    const session = (await getServerSession(authOptions as any)) as import('next-auth').Session | null;
+    if (!session?.user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const userRole = (session.user as any)?.platform_role;
+    if (userRole !== 'admin') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const { leagueId } = await params;
+    const adminUserId = (session.user as any)?.id;
+    const supabase = getSupabaseServiceRole();
+
+    // Verify league exists
+    const { data: league, error: leagueError } = await supabase
+      .from('leagues')
+      .select('league_id')
+      .eq('league_id', leagueId)
+      .single();
+
+    if (leagueError || !league) {
+      return NextResponse.json({ error: 'League not found' }, { status: 404 });
+    }
+
+    // Get host role_id
+    const { data: hostRole, error: roleError } = await supabase
+      .from('roles')
+      .select('role_id')
+      .eq('role_name', 'host')
+      .single();
+
+    if (roleError || !hostRole) {
+      return NextResponse.json({ error: 'Host role not found' }, { status: 500 });
+    }
+
+    // Insert into leaguemembers if not already there
+    const { data: existingMember } = await supabase
+      .from('leaguemembers')
+      .select('league_member_id')
+      .eq('league_id', leagueId)
+      .eq('user_id', adminUserId)
+      .maybeSingle();
+
+    if (!existingMember) {
+      const { error: memberError } = await supabase
+        .from('leaguemembers')
+        .insert({ league_id: leagueId, user_id: adminUserId });
+
+      if (memberError) {
+        console.error('Error inserting league member:', memberError);
+        return NextResponse.json({ error: 'Failed to add admin to league' }, { status: 500 });
+      }
+    }
+
+    // Insert host role if not already assigned
+    const { data: existingRole } = await supabase
+      .from('assignedrolesforleague')
+      .select('id')
+      .eq('league_id', leagueId)
+      .eq('user_id', adminUserId)
+      .eq('role_id', hostRole.role_id)
+      .maybeSingle();
+
+    if (!existingRole) {
+      const { error: roleAssignError } = await supabase
+        .from('assignedrolesforleague')
+        .insert({
+          league_id: leagueId,
+          user_id: adminUserId,
+          role_id: hostRole.role_id,
+          created_by: adminUserId,
+        });
+
+      if (roleAssignError) {
+        console.error('Error assigning host role:', roleAssignError);
+        return NextResponse.json({ error: 'Failed to assign host role' }, { status: 500 });
+      }
+    }
+
+    return NextResponse.json({ success: true, redirect: `/leagues/${leagueId}` });
+  } catch (error) {
+    console.error('Error in impersonate POST:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+/**
+ * DELETE /api/admin/leagues/[leagueId]/impersonate
+ * Removes the admin's temporary host access from a specific league.
+ */
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ leagueId: string }> }
+) {
+  try {
+    const session = (await getServerSession(authOptions as any)) as import('next-auth').Session | null;
+    if (!session?.user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const userRole = (session.user as any)?.platform_role;
+    if (userRole !== 'admin') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const { leagueId } = await params;
+    const adminUserId = (session.user as any)?.id;
+    const supabase = getSupabaseServiceRole();
+
+    // Remove role assignments for this admin in this league
+    await supabase
+      .from('assignedrolesforleague')
+      .delete()
+      .eq('league_id', leagueId)
+      .eq('user_id', adminUserId);
+
+    // Remove league membership
+    await supabase
+      .from('leaguemembers')
+      .delete()
+      .eq('league_id', leagueId)
+      .eq('user_id', adminUserId);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error in impersonate DELETE:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/components/admin/leagues-table.tsx
+++ b/src/components/admin/leagues-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { useRouter } from "next/navigation";
 import {
   ChevronLeft,
   ChevronRight,
@@ -17,6 +18,8 @@ import {
   Loader2,
   Globe,
   Lock,
+  LogIn,
+  UserCircle,
 } from "lucide-react";
 import {
   flexRender,
@@ -115,6 +118,8 @@ export function LeaguesTable() {
   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false);
   const [leagueToDelete, setLeagueToDelete] = React.useState<AdminLeague | null>(null);
   const [isDeleting, setIsDeleting] = React.useState(false);
+  const [isImpersonating, setIsImpersonating] = React.useState<string | null>(null);
+  const router = useRouter();
 
   // Fetch leagues with hook
   const { leagues, isLoading, error, createLeague, updateLeague, deleteLeague, refetch } =
@@ -152,6 +157,26 @@ export function LeaguesTable() {
       } else {
         toast.error("Failed to deactivate league");
       }
+    }
+  };
+
+  const handleLoginAsHost = async (league: AdminLeague) => {
+    setIsImpersonating(league.league_id);
+    try {
+      const res = await fetch(`/api/admin/leagues/${league.league_id}/impersonate`, {
+        method: 'POST',
+      });
+      const json = await res.json();
+      if (res.ok && json.success) {
+        toast.success(`Entering "${league.league_name}" as Host`);
+        router.push(json.redirect || `/leagues/${league.league_id}`);
+      } else {
+        toast.error(json.error || 'Failed to impersonate');
+      }
+    } catch (err) {
+      toast.error('Failed to login as host');
+    } finally {
+      setIsImpersonating(null);
     }
   };
 
@@ -282,6 +307,30 @@ export function LeaguesTable() {
       ),
     },
     {
+      accessorKey: "host_name",
+      header: "Host",
+      cell: ({ row }) => {
+        const hostName = row.original.host_name;
+        const hostEmail = row.original.host_email;
+        const hostPhone = row.original.host_phone;
+        if (!hostName) return <span className="text-muted-foreground text-sm">—</span>;
+        return (
+          <div className="min-w-[120px]">
+            <div className="flex items-center gap-1.5">
+              <UserCircle className="size-4 text-muted-foreground shrink-0" />
+              <span className="font-medium text-sm">{hostName}</span>
+            </div>
+            {hostEmail && (
+              <div className="text-xs text-muted-foreground truncate max-w-[180px]">{hostEmail}</div>
+            )}
+            {hostPhone && (
+              <div className="text-xs text-muted-foreground">{hostPhone}</div>
+            )}
+          </div>
+        );
+      },
+    },
+    {
       accessorKey: "num_teams",
       header: "Teams",
       cell: ({ row }) => (
@@ -314,6 +363,18 @@ export function LeaguesTable() {
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="w-40">
+            <DropdownMenuItem
+              onClick={() => handleLoginAsHost(row.original)}
+              disabled={isImpersonating === row.original.league_id}
+            >
+              {isImpersonating === row.original.league_id ? (
+                <Loader2 className="mr-2 size-4 animate-spin" />
+              ) : (
+                <LogIn className="mr-2 size-4" />
+              )}
+              Login as Host
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
             <DropdownMenuItem onClick={() => handleEditLeague(row.original)}>
               <Pencil className="mr-2 size-4" />
               Edit

--- a/src/lib/services/admin/admin-leagues.ts
+++ b/src/lib/services/admin/admin-leagues.ts
@@ -83,12 +83,29 @@ export async function getAllLeagues(filters?: AdminLeagueFilters): Promise<Admin
       countMap[m.league_id] = (countMap[m.league_id] || 0) + 1;
     });
 
-    return leagues.map((league) =>
-      mapDbLeagueToAdminLeague({
+    // Get host user info for all leagues
+    const hostIds = [...new Set(leagues.map((l) => l.created_by).filter(Boolean))];
+    const hostMap: Record<string, { username: string; email: string; phone?: string | null }> = {};
+    if (hostIds.length > 0) {
+      const { data: hostUsers } = await supabase
+        .from('users')
+        .select('user_id, username, email, phone')
+        .in('user_id', hostIds);
+      (hostUsers || []).forEach((u: any) => {
+        hostMap[u.user_id] = { username: u.username, email: u.email, phone: u.phone };
+      });
+    }
+
+    return leagues.map((league) => {
+      const host = league.created_by ? hostMap[league.created_by] : null;
+      return mapDbLeagueToAdminLeague({
         ...league,
         member_count: countMap[league.league_id] || 0,
-      })
-    );
+        host_name: host?.username || null,
+        host_email: host?.email || null,
+        host_phone: host?.phone || null,
+      });
+    });
   } catch (err) {
     console.error('Error in getAllLeagues:', err);
     return [];

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -72,6 +72,9 @@ export interface AdminLeague {
   // Computed fields
   member_count?: number;
   league_capacity?: number;
+  host_name?: string | null;
+  host_email?: string | null;
+  host_phone?: string | null;
 }
 
 export interface AdminLeagueCreateInput {


### PR DESCRIPTION
## Summary
- **Host info column** in admin leagues table showing host name, email, and phone
- **Login as Host** action in league dropdown — admin gets temporary host access to any league
- **Admin Mode banner** with warning: "Your access will be removed when you leave this page"
- **Auto-cleanup** on admin layout mount removes any orphaned temp roles
- **Exit button** in banner for immediate cleanup + redirect to admin

## How it works
1. Admin clicks "Login as Host" on any league → API inserts temp host role + league membership
2. Admin is redirected to the league with full host access
3. On exit (banner button, navigating to admin, or next admin page visit), temp roles are cleaned up

## Files changed
- `src/types/admin.ts` — added host_name, host_email, host_phone fields
- `src/lib/services/admin/admin-leagues.ts` — join host user info
- `src/components/admin/leagues-table.tsx` — Host column + Login as Host action
- `src/app/api/admin/leagues/[leagueId]/impersonate/route.ts` — POST/DELETE impersonate
- `src/app/api/admin/impersonate/cleanup/route.ts` — bulk cleanup
- `src/app/(app)/layout.tsx` — admin mode banner + auto-cleanup
- `src/app/(admin)/admin/layout.tsx` — auto-cleanup on mount

## Test plan
- [ ] Admin leagues table shows Host column with name/email/phone
- [ ] "Login as Host" grants full host access to the league
- [ ] Admin mode banner visible with warning text
- [ ] "Exit Admin Mode" cleans up and redirects to /admin/leagues
- [ ] Navigating to any /admin page auto-cleans orphaned roles