### PR TITLE
Fix admin impersonation, submit crash, rest days, UI restructure

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -81,6 +81,9 @@ export default function AppLayout({
     } catch (err) {
       console.error('Error cleaning up impersonation:', err);
     }
+    // Clear impersonation state from localStorage
+    localStorage.removeItem('activeLeagueId');
+    localStorage.removeItem(`role_${impersonatingLeagueId}`);
     router.push('/admin/leagues');
   }, [impersonatingLeagueId, router]);
 

--- a/src/app/(app)/leagues/[id]/my-team-view/page.tsx
+++ b/src/app/(app)/leagues/[id]/my-team-view/page.tsx
@@ -14,6 +14,8 @@ import {
   Flame,
   AlertCircle,
   Star,
+  Moon,
+  XCircle,
 } from 'lucide-react';
 
 import { useLeague } from '@/contexts/league-context';
@@ -72,6 +74,8 @@ export default function MyTeamViewPage({
   const [teamActivityPoints, setTeamActivityPoints] = useState<number | null>(null);
   const [teamChallengePoints, setTeamChallengePoints] = useState<number | null>(null);
   const [teamLogoUrl, setTeamLogoUrl] = useState<string | null>(null);
+  const [teamMissedDays, setTeamMissedDays] = useState<number | null>(null);
+  const [teamRestUsed, setTeamRestUsed] = useState<number | null>(null);
 
   const userTeamId = activeLeague?.team_id;
   const userTeamName = activeLeague?.team_name;
@@ -156,7 +160,7 @@ export default function MyTeamViewPage({
     },
     {
       title: 'Team Members',
-      value: `${members.length}/${teamCapacity}`,
+      value: `${members.length}`,
       description: 'Current roster',
       icon: Users,
     },
@@ -184,6 +188,18 @@ export default function MyTeamViewPage({
       description: 'Bonus points',
       icon: Star,
     },
+    {
+      title: 'Rest Days Used',
+      value: typeof teamRestUsed === 'number' ? teamRestUsed.toLocaleString() : '—',
+      description: 'Team total',
+      icon: Moon,
+    },
+    {
+      title: 'Days Missed',
+      value: typeof teamMissedDays === 'number' ? teamMissedDays.toLocaleString() : '—',
+      description: 'No submission',
+      icon: XCircle,
+    },
   ];
 
   // Fetch leaderboard stats for this team
@@ -210,6 +226,22 @@ export default function MyTeamViewPage({
         const logoJson = await logoRes.json();
         if (logoRes.ok && logoJson?.success && logoJson.data?.logo_url) {
           setTeamLogoUrl(logoJson.data.logo_url);
+        }
+
+        // Fetch team summary (rest days used + missed days)
+        try {
+          const summaryRes = await fetch(`/api/leagues/${leagueId}/my-team/summary`);
+          const summaryJson = await summaryRes.json();
+          if (summaryRes.ok && summaryJson?.success && summaryJson.data) {
+            if (typeof summaryJson.data.restUsed === 'number') {
+              setTeamRestUsed(summaryJson.data.restUsed);
+            }
+            if (typeof summaryJson.data.missedDays === 'number') {
+              setTeamMissedDays(summaryJson.data.missedDays);
+            }
+          }
+        } catch (err) {
+          console.error('Error fetching team summary:', err);
         }
       } catch (err) {
         console.error('Error fetching team leaderboard stats (view):', err);
@@ -294,7 +326,7 @@ export default function MyTeamViewPage({
           )}
           <Badge variant="outline">
             <Users className="size-3 mr-1" />
-            {members.length}/{teamCapacity} Members
+            {members.length} Members
           </Badge>
         </div>
       </div>
@@ -311,7 +343,7 @@ export default function MyTeamViewPage({
       )}
 
       {/* Stats Cards */}
-      <div className="grid grid-cols-2 gap-1 px-4 lg:px-6">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-1 px-4 lg:px-6">
         {stats.map((stat, index) => {
           const StatIcon = stat.icon;
           return (

--- a/src/app/(app)/leagues/[id]/page.tsx
+++ b/src/app/(app)/leagues/[id]/page.tsx
@@ -20,7 +20,6 @@ import {
   Lock,
   ArrowRight,
   Zap,
-  Medal,
   Timer,
   TrendingUp,
   RefreshCw,
@@ -200,6 +199,7 @@ export default function LeagueDashboardPage({
     teamRestUsed: number | null;
     teamActivityPoints?: number;
     teamChallengePoints?: number;
+    teamRank?: number | null;
   } | null>(null);
 
   // Sync active league if navigated directly
@@ -617,6 +617,7 @@ export default function LeagueDashboardPage({
         let challengePoints = 0;
         let teamActivityPoints = 0;
         let teamChallengePoints = 0;
+        let teamRank: number | null = null;
 
         try {
           const tzOffsetMinutes = new Date().getTimezoneOffset();
@@ -649,6 +650,16 @@ export default function LeagueDashboardPage({
               // Use team's base points (before challenge bonus) for activity points
               teamActivityPoints = mine && typeof mine.points === 'number' ? Math.max(0, mine.points) : 0;
               teamChallengePoints = mine && typeof mine.challenge_bonus === 'number' ? Math.max(0, mine.challenge_bonus) : 0;
+
+              // Extract team rank
+              if (mine && typeof (mine as any).rank === 'number') {
+                teamRank = (mine as any).rank;
+              } else {
+                // Derive rank from position in sorted array
+                const sortedTeams = [...teams].sort((a, b) => (b.total_points ?? b.points ?? 0) - (a.total_points ?? a.points ?? 0));
+                const idx = sortedTeams.findIndex((t) => String(t.team_id) === String(teamId));
+                teamRank = idx >= 0 ? idx + 1 : null;
+              }
             }
 
             // Individual stats: challenge points are no longer added to individual totals.
@@ -676,6 +687,7 @@ export default function LeagueDashboardPage({
           teamRestUsed,
           teamActivityPoints,
           teamChallengePoints,
+          teamRank,
         };
         setMySummary(summaryData);
 
@@ -1165,7 +1177,7 @@ export default function LeagueDashboardPage({
                 <CardTitle className="text-base">Team Summary</CardTitle>
               </CardHeader>
               <CardContent className="space-y-3">
-                <div className="grid grid-cols-2 gap-3">
+                <div className="grid grid-cols-3 gap-3">
                   <div className="rounded-md border border-primary/20 bg-primary/10 dark:bg-primary/20 px-3 py-2.5 text-center">
                     <div className="text-xs text-muted-foreground">Total Points</div>
                     <div className="text-base font-semibold text-foreground tabular-nums">
@@ -1175,7 +1187,7 @@ export default function LeagueDashboardPage({
                     </div>
                   </div>
                   <div className="rounded-md border border-border/60 bg-muted/40 px-3 py-2.5 text-center">
-                    <div className="text-xs text-muted-foreground">Avg RR</div>
+                    <div className="text-xs text-muted-foreground">Run Rate</div>
                     <div className="text-base font-semibold text-foreground tabular-nums">
                       {typeof mySummary?.teamAvgRR === 'number'
                         ? mySummary.teamAvgRR.toFixed(2)
@@ -1183,34 +1195,10 @@ export default function LeagueDashboardPage({
                     </div>
                   </div>
                   <div className="rounded-md border border-border/60 bg-muted/40 px-3 py-2.5 text-center">
-                    <div className="text-xs text-muted-foreground">Activity Points</div>
+                    <div className="text-xs text-muted-foreground">Team Rank</div>
                     <div className="text-base font-semibold text-foreground tabular-nums">
-                      {typeof mySummary?.teamActivityPoints === 'number'
-                        ? mySummary.teamActivityPoints.toLocaleString()
-                        : '—'}
-                    </div>
-                  </div>
-                  <div className="rounded-md border border-border/60 bg-muted/40 px-3 py-2.5 text-center">
-                    <div className="text-xs text-muted-foreground">Challenge Points</div>
-                    <div className="text-base font-semibold text-foreground tabular-nums">
-                      {typeof mySummary?.teamChallengePoints === 'number'
-                        ? mySummary.teamChallengePoints.toLocaleString()
-                        : '—'}
-                    </div>
-                  </div>
-                  <div className="rounded-md border border-border/60 bg-muted/40 px-3 py-2.5 text-center">
-                    <div className="text-xs text-muted-foreground">Days Missed</div>
-                    <div className="text-sm font-semibold text-foreground tabular-nums">
-                      {typeof mySummary?.teamMissedDays === 'number'
-                        ? mySummary.teamMissedDays.toLocaleString()
-                        : '—'}
-                    </div>
-                  </div>
-                  <div className="rounded-md border border-border/60 bg-muted/40 px-3 py-2.5 text-center">
-                    <div className="text-xs text-muted-foreground">Rest Days Used</div>
-                    <div className="text-sm font-semibold text-foreground tabular-nums">
-                      {typeof mySummary?.teamRestUsed === 'number'
-                        ? mySummary.teamRestUsed.toLocaleString()
+                      {typeof mySummary?.teamRank === 'number'
+                        ? `#${mySummary.teamRank}`
                         : '—'}
                     </div>
                   </div>
@@ -1394,11 +1382,17 @@ export default function LeagueDashboardPage({
         </Link>
       </div>
 
-      {/* Progress Bar (for launched/active leagues) */}
-      {(league.status === 'active' || league.status === 'launched') && (
-        <div className="px-4 lg:px-6">
-          <Card className="bg-gradient-to-r from-primary/5 via-transparent to-primary/5 border-primary/20">
-            <CardContent className="p-4">
+      {/* League Information */}
+      <div className="px-4 lg:px-6">
+        <div className="mb-4">
+          <h2 className="text-lg font-semibold">League Information</h2>
+          <p className="text-sm text-muted-foreground">Configuration and settings overview</p>
+        </div>
+
+        <div className="rounded-lg border">
+          {/* Progress Bar (for launched/active leagues) */}
+          {(league.status === 'active' || league.status === 'launched') && (
+            <div className="p-4 border-b">
               <div className="flex items-center justify-between mb-3">
                 <div className="flex items-center gap-2">
                   <Flame className="size-5 text-primary" />
@@ -1417,37 +1411,24 @@ export default function LeagueDashboardPage({
                   <span className="font-semibold text-foreground">{daysRemaining}</span> days remaining
                 </span>
               </div>
-              <div className="flex justify-between mt-2 text-xs text-muted-foreground">
-                <span>{formatDate(league.start_date)} — {formatDate(league.end_date)}</span>
-                <span><span className="font-semibold text-foreground">{league.league_capacity || 0}</span> players</span>
-              </div>
-            </CardContent>
-          </Card>
-        </div>
-      )}
+            </div>
+          )}
 
-      {/* League Information - Table Style */}
-      <div className="px-4 lg:px-6">
-        <div className="mb-4">
-          <h2 className="text-lg font-semibold">League Information</h2>
-          <p className="text-sm text-muted-foreground">Configuration and settings overview</p>
-        </div>
-
-        <div className="rounded-lg border">
-          <div className="grid grid-cols-2 md:grid-cols-3 divide-x divide-y md:divide-y-0">
+          {/* Key stats */}
+          <div className="grid grid-cols-2 md:grid-cols-4 divide-x divide-y md:divide-y-0">
             <div className="p-4 flex flex-col items-center text-center">
               <div className="size-10 rounded-lg bg-primary/10 flex items-center justify-center mb-2">
-                <Users className="size-5 text-primary" />
+                <Calendar className="size-5 text-primary" />
               </div>
-              <p className="text-2xl font-bold tabular-nums">{league.num_teams || 0}</p>
-              <p className="text-xs text-muted-foreground">Teams</p>
+              <p className="text-sm font-bold text-primary tabular-nums">{formatDate(league.start_date)}</p>
+              <p className="text-xs text-muted-foreground">Start Date</p>
             </div>
             <div className="p-4 flex flex-col items-center text-center">
               <div className="size-10 rounded-lg bg-primary/10 flex items-center justify-center mb-2">
-                <Medal className="size-5 text-primary" />
+                <Calendar className="size-5 text-primary" />
               </div>
-              <p className="text-2xl font-bold tabular-nums">{league.league_capacity || 0}</p>
-              <p className="text-xs text-muted-foreground">Max Capacity</p>
+              <p className="text-sm font-bold text-primary tabular-nums">{formatDate(league.end_date)}</p>
+              <p className="text-xs text-muted-foreground">End Date</p>
             </div>
             <div className="p-4 flex flex-col items-center text-center">
               <div className="size-10 rounded-lg bg-primary/10 flex items-center justify-center mb-2">
@@ -1456,10 +1437,24 @@ export default function LeagueDashboardPage({
               <p className="text-2xl font-bold tabular-nums">{totalDays}</p>
               <p className="text-xs text-muted-foreground">Days Total</p>
             </div>
+            <div className="p-4 flex flex-col items-center text-center">
+              <div className="size-10 rounded-lg bg-primary/10 flex items-center justify-center mb-2">
+                <Moon className="size-5 text-primary" />
+              </div>
+              <p className="text-2xl font-bold tabular-nums">{league.rest_days}</p>
+              <p className="text-xs text-muted-foreground">Rest Days</p>
+            </div>
           </div>
 
+          {/* Bottom row: Teams, Players, Visibility, Join Type */}
           <div className="border-t p-4">
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+              <div className="flex flex-col gap-1 md:flex-col md:items-start min-w-0">
+                <span className="text-sm text-muted-foreground">Teams</span>
+                <Badge variant="outline">
+                  {league.num_teams || 0} teams
+                </Badge>
+              </div>
               <div className="flex flex-col gap-1 md:flex-col md:items-start min-w-0">
                 <span className="text-sm text-muted-foreground">Visibility</span>
                 <Badge variant={league.is_public ? 'default' : 'secondary'}>
@@ -1471,25 +1466,9 @@ export default function LeagueDashboardPage({
                 </Badge>
               </div>
               <div className="flex flex-col gap-1 md:flex-col md:items-start min-w-0">
-
                 <span className="text-sm text-muted-foreground">Join Type</span>
                 <Badge variant="outline">
                   {league.is_exclusive ? 'Invite Only' : 'Open'}
-                </Badge>
-              </div>
-              <div className="flex flex-col gap-1 md:flex-col md:items-start min-w-0">
-
-                <span className="text-sm text-muted-foreground">Rest Days</span>
-                <Badge variant="outline">
-                  {league.rest_days} total
-                </Badge>
-              </div>
-              <div className="flex flex-col gap-1 md:flex-col md:items-start min-w-0">
-
-                <span className="text-sm text-muted-foreground">Schedule</span>
-                <Badge variant="outline" className="text-xs max-w-full whitespace-normal break-words text-left leading-tight flex items-center gap-1">
-                  <Calendar className="size-3" />
-                  {formatDate(league.start_date)} - {formatDate(league.end_date)}
                 </Badge>
               </div>
             </div>

--- a/src/app/(app)/leagues/[id]/settings/page.tsx
+++ b/src/app/(app)/leagues/[id]/settings/page.tsx
@@ -112,11 +112,11 @@ export default function LeagueSettingsPage({
     is_exclusive: true,
     num_teams: '4',
     rest_days: '1',
-    auto_rest_day_enabled: false,
+    auto_rest_day_enabled: true,
     start_date: '',
     end_date: '',
     status: 'draft' as 'draft' | 'launched' | 'active' | 'completed',
-    normalize_points_by_team_size: false,
+    normalize_points_by_team_size: true,
     max_team_capacity: '10',
   });
 
@@ -649,17 +649,14 @@ export default function LeagueSettingsPage({
                   <div className="flex items-center gap-2">
                     <Label className="flex items-center gap-2">
                       <Globe className="size-4 text-muted-foreground" />
-                      Public League
+                      Private League
                     </Label>
-                    <FieldInfoButton text="Public leagues appear in discovery, anyone can find and view the league and join." />
+                    <FieldInfoButton text="Private leagues are not publicly discoverable. Members can only join via invite code." />
                   </div>
                 </div>
                 <Switch
-                  checked={formData.is_public}
-                  onCheckedChange={(checked) =>
-                    setFormData((prev) => ({ ...prev, is_public: checked }))
-                  }
-                  disabled={!canEditStructure}
+                  checked={true}
+                  disabled
                 />
               </div>
 

--- a/src/app/(app)/leagues/[id]/submit/page.tsx
+++ b/src/app/(app)/leagues/[id]/submit/page.tsx
@@ -100,7 +100,7 @@ export default function SubmitActivityPage({
   const { id: leagueId } = React.use(params);
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { activeLeague } = useLeague();
+  const { activeLeague, isLoading: leagueLoading } = useLeague();
   const { canSubmitWorkouts } = useRole();
 
   // Fetch user profile for age calculation
@@ -257,13 +257,13 @@ export default function SubmitActivityPage({
   }, [maxActivityDate, yesterday, leagueStartLocal, today]);
 
   // Effect to clamp activityDate into the allowed window (yesterday through maxActivityDate)
+  // NOTE: activityDate is intentionally NOT in the dependency array to prevent infinite loops.
+  // This effect runs only when the allowed window boundaries change.
   React.useEffect(() => {
     if (!maxActivityDate || !minActivityDate) return;
 
     const current = startOfDay(activityDate);
 
-    // If current is wildly out of range vs max, clamp it.
-    // Specially handle the "Trial" case where current might be < start_date but valid.
     if (isAfter(current, maxActivityDate)) {
       setActivityDate(maxActivityDate);
       toast.info(`Date adjusted to latest allowed (${format(maxActivityDate, 'yyyy-MM-dd')})`);
@@ -271,7 +271,8 @@ export default function SubmitActivityPage({
       setActivityDate(minActivityDate);
       toast.info(`Date adjusted to earliest allowed (${format(minActivityDate, 'yyyy-MM-dd')})`);
     }
-  }, [maxActivityDate, minActivityDate, activityDate]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [maxActivityDate, minActivityDate]);
 
   // Check for trial mode (before league start)
   const isTrialMode = React.useMemo(() => {
@@ -1013,8 +1014,16 @@ export default function SubmitActivityPage({
     }
   };
 
-  // Access check
+  // Access check — wait for league context to finish loading before denying access
   if (!canSubmitWorkouts) {
+    if (leagueLoading || !activeLeague) {
+      return (
+        <div className="flex flex-1 flex-col items-center justify-center gap-4 p-4 lg:gap-6 lg:p-6">
+          <div className="size-8 border-4 border-primary border-t-transparent rounded-full animate-spin" />
+          <p className="text-muted-foreground">Loading...</p>
+        </div>
+      );
+    }
     return (
       <div className="flex flex-1 flex-col gap-4 p-4 lg:gap-6 lg:p-6">
         <Alert variant="destructive">

--- a/src/app/api/admin/leagues/[leagueId]/impersonate/route.ts
+++ b/src/app/api/admin/leagues/[leagueId]/impersonate/route.ts
@@ -37,14 +37,20 @@ export async function POST(
       return NextResponse.json({ error: 'League not found' }, { status: 404 });
     }
 
-    // Get host role_id
-    const { data: hostRole, error: roleError } = await supabase
+    // Get host and player role IDs
+    const { data: roles, error: roleError } = await supabase
       .from('roles')
-      .select('role_id')
-      .eq('role_name', 'host')
-      .single();
+      .select('role_id, role_name')
+      .in('role_name', ['host', 'player']);
 
-    if (roleError || !hostRole) {
+    if (roleError || !roles || roles.length === 0) {
+      return NextResponse.json({ error: 'Roles not found' }, { status: 500 });
+    }
+
+    const hostRole = roles.find((r: any) => r.role_name === 'host');
+    const playerRole = roles.find((r: any) => r.role_name === 'player');
+
+    if (!hostRole) {
       return NextResponse.json({ error: 'Host role not found' }, { status: 500 });
     }
 
@@ -92,7 +98,29 @@ export async function POST(
       }
     }
 
-    return NextResponse.json({ success: true, redirect: `/leagues/${leagueId}` });
+    // Also assign player role so admin can access player-facing pages without errors
+    if (playerRole) {
+      const { data: existingPlayerRole } = await supabase
+        .from('assignedrolesforleague')
+        .select('id')
+        .eq('league_id', leagueId)
+        .eq('user_id', adminUserId)
+        .eq('role_id', playerRole.role_id)
+        .maybeSingle();
+
+      if (!existingPlayerRole) {
+        await supabase
+          .from('assignedrolesforleague')
+          .insert({
+            league_id: leagueId,
+            user_id: adminUserId,
+            role_id: playerRole.role_id,
+            created_by: adminUserId,
+          });
+      }
+    }
+
+    return NextResponse.json({ success: true, redirect: `/leagues/${leagueId}/settings` });
   } catch (error) {
     console.error('Error in impersonate POST:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/src/app/api/cron/auto-rest-day/route.ts
+++ b/src/app/api/cron/auto-rest-day/route.ts
@@ -102,13 +102,19 @@ async function getMemberRestDaysRemaining(
   // Calculate total allowed rest days
   const totalAllowed = totalRestDaysLimit;
 
-  // Count approved rest days (auto-calculated from effortentry)
-  const { count: approvedRestDays } = await supabase
+  // Count approved rest days from league start date onwards (exclude practice/trial days)
+  let cronRestQuery = supabase
     .from('effortentry')
     .select('*', { count: 'exact', head: true })
     .eq('league_member_id', leagueMemberId)
     .eq('type', 'rest')
     .eq('status', 'approved');
+
+  if (league.start_date) {
+    cronRestQuery = cronRestQuery.gte('date', league.start_date);
+  }
+
+  const { count: approvedRestDays } = await cronRestQuery;
 
   const autoUsed = approvedRestDays || 0;
 

--- a/src/app/api/leagues/[id]/activities/route.ts
+++ b/src/app/api/leagues/[id]/activities/route.ts
@@ -11,6 +11,29 @@ import { authOptions } from '@/lib/auth/config';
 import { getSupabaseServiceRole } from '@/lib/supabase/client';
 
 // ============================================================================
+// Helper: Check if user is host (creator OR assigned host role)
+// ============================================================================
+
+async function checkIsHost(supabase: any, leagueId: string, userId: string): Promise<boolean> {
+  const { data: league } = await supabase
+    .from('leagues')
+    .select('created_by')
+    .eq('league_id', leagueId)
+    .single();
+
+  if (league?.created_by === userId) return true;
+
+  const { data: roleData } = await supabase
+    .from('assignedrolesforleague')
+    .select('roles(role_name)')
+    .eq('user_id', userId)
+    .eq('league_id', leagueId);
+
+  const roleNames = (roleData || []).map((r: any) => r.roles?.role_name).filter(Boolean);
+  return roleNames.includes('host');
+}
+
+// ============================================================================
 // Types
 // ============================================================================
 
@@ -59,14 +82,9 @@ export async function PATCH(
     const userId = session.user.id;
     const supabase = getSupabaseServiceRole();
 
-    // Check if user is host of this league
-    const { data: league } = await supabase
-      .from('leagues')
-      .select('created_by')
-      .eq('league_id', leagueId)
-      .single();
-
-    if (league?.created_by !== userId) {
+    // Check if user is host of this league (creator or assigned host role)
+    const isHostUser = await checkIsHost(supabase, leagueId, userId);
+    if (!isHostUser) {
       return NextResponse.json(
         { error: 'Only the league host can configure activities' },
         { status: 403 }
@@ -252,16 +270,7 @@ export async function GET(
       .eq('league_id', leagueId)
       .maybeSingle();
 
-    // Also check if user is host
-    const { data: league } = await supabase
-      .from('leagues')
-      .select('created_by')
-      .eq('league_id', leagueId)
-      .single();
-
-    const isHost = league?.created_by === session.user.id;
-
-    // Check if user is Governor in this league
+    // Check user roles in this league
     const { data: roleData } = await supabase
       .from('assignedrolesforleague')
       .select('roles(role_name)')
@@ -269,6 +278,15 @@ export async function GET(
       .eq('league_id', leagueId);
 
     const roleNames = (roleData || []).map((r: any) => r.roles?.role_name).filter(Boolean);
+
+    // Also check if user is league creator
+    const { data: league } = await supabase
+      .from('leagues')
+      .select('created_by')
+      .eq('league_id', leagueId)
+      .single();
+
+    const isHost = league?.created_by === session.user.id || roleNames.includes('host');
     const isGovernor = roleNames.includes('governor');
 
     if (!membership && !isHost && !isGovernor) {
@@ -553,14 +571,9 @@ export async function POST(
     const userId = session.user.id;
     const supabase = getSupabaseServiceRole();
 
-    // Check if user is host of this league
-    const { data: league } = await supabase
-      .from('leagues')
-      .select('created_by')
-      .eq('league_id', leagueId)
-      .single();
-
-    if (league?.created_by !== userId) {
+    // Check if user is host of this league (creator or assigned host role)
+    const isHostUser = await checkIsHost(supabase, leagueId, userId);
+    if (!isHostUser) {
       return NextResponse.json(
         { error: 'Only the league host can configure activities' },
         { status: 403 }
@@ -763,14 +776,9 @@ export async function DELETE(
     const userId = session.user.id;
     const supabase = getSupabaseServiceRole();
 
-    // Check if user is host of this league
-    const { data: league } = await supabase
-      .from('leagues')
-      .select('created_by')
-      .eq('league_id', leagueId)
-      .single();
-
-    if (league?.created_by !== userId) {
+    // Check if user is host of this league (creator or assigned host role)
+    const isHostUser = await checkIsHost(supabase, leagueId, userId);
+    if (!isHostUser) {
       return NextResponse.json(
         { error: 'Only the league host can configure activities' },
         { status: 403 }

--- a/src/app/api/leagues/[id]/my-team/submissions/route.ts
+++ b/src/app/api/leagues/[id]/my-team/submissions/route.ts
@@ -106,15 +106,15 @@ export async function GET(
       .eq('league_id', leagueId)
       .single();
 
-    const { data: governorRole } = await supabase
+    const { data: userRoles } = await supabase
       .from('assignedrolesforleague')
       .select('role_id, roles!inner(role_name)')
       .eq('user_id', userId)
-      .eq('league_id', leagueId)
-      .maybeSingle();
+      .eq('league_id', leagueId);
 
-    const isHost = leagueData?.created_by === userId;
-    const isGovernor = (governorRole?.roles as any)?.role_name === 'governor';
+    const userRoleNames = (userRoles || []).map((r: any) => r.roles?.role_name).filter(Boolean);
+    const isHost = leagueData?.created_by === userId || userRoleNames.includes('host');
+    const isGovernor = userRoleNames.includes('governor');
 
     if (!isCaptain && !isHost && !isGovernor) {
       return NextResponse.json(

--- a/src/app/api/leagues/[id]/rest-days/route.ts
+++ b/src/app/api/leagues/[id]/rest-days/route.ts
@@ -50,26 +50,38 @@ export async function GET(
     // Treat rest_days as total allowed rest days (previously per-week)
     const totalAllowedRestDays = league.rest_days ?? 1;
 
-    // Count rest days used (approved only)
-    const { count: approvedRestDays, error: approvedError } = await supabase
+    // Count rest days used (approved only, from league start date onwards)
+    let restDayQuery = supabase
       .from('effortentry')
       .select('*', { count: 'exact', head: true })
       .eq('league_member_id', membership.league_member_id)
       .eq('type', 'rest')
       .eq('status', 'approved');
 
+    if (league.start_date) {
+      restDayQuery = restDayQuery.gte('date', league.start_date);
+    }
+
+    const { count: approvedRestDays, error: approvedError } = await restDayQuery;
+
     if (approvedError) {
       console.error('Error counting approved rest days:', approvedError);
       return NextResponse.json({ error: 'Failed to fetch rest day stats' }, { status: 500 });
     }
 
-    // Count pending rest days (not yet approved)
-    const { count: pendingRestDays, error: pendingError } = await supabase
+    // Count pending rest days (not yet approved, from league start date onwards)
+    let pendingQuery = supabase
       .from('effortentry')
       .select('*', { count: 'exact', head: true })
       .eq('league_member_id', membership.league_member_id)
       .eq('type', 'rest')
       .eq('status', 'pending');
+
+    if (league.start_date) {
+      pendingQuery = pendingQuery.gte('date', league.start_date);
+    }
+
+    const { count: pendingRestDays, error: pendingError } = await pendingQuery;
 
     if (pendingError) {
       console.error('Error counting pending rest days:', pendingError);

--- a/src/components/admin/leagues-table.tsx
+++ b/src/components/admin/leagues-table.tsx
@@ -168,8 +168,11 @@ export function LeaguesTable() {
       });
       const json = await res.json();
       if (res.ok && json.success) {
+        // Force league context to load this league with host role
+        localStorage.setItem('activeLeagueId', league.league_id);
+        localStorage.setItem(`role_${league.league_id}`, 'host');
         toast.success(`Entering "${league.league_name}" as Host`);
-        router.push(json.redirect || `/leagues/${league.league_id}`);
+        router.push(json.redirect || `/leagues/${league.league_id}/settings`);
       } else {
         toast.error(json.error || 'Failed to impersonate');
       }

--- a/src/components/app/app-sidebar.tsx
+++ b/src/components/app/app-sidebar.tsx
@@ -6,29 +6,17 @@ import { usePathname } from 'next/navigation';
 import { signOut } from 'next-auth/react';
 import {
   LogOut,
-  Settings,
-  HelpCircle,
-  ChevronRight,
   MoreVertical,
-  CreditCard,
-  Palette,
 } from 'lucide-react';
 
 import { useLeague } from '@/contexts/league-context';
 import { useRole } from '@/contexts/role-context';
 import { getSidebarNavItems, NavSection } from '@/lib/navigation/sidebar-config';
-import { ThemeDrawer } from '@/components/theme-drawer';
 import { LeagueSwitcher } from './league-switcher';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from '@/components/ui/collapsible';
-import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
@@ -72,8 +60,6 @@ export function AppSidebar({ user, ...props }: AppSidebarProps) {
   const { activeRole, isAlsoPlayer } = useRole();
   const { state, setOpenMobile } = useSidebar();
   const isCollapsed = state === 'collapsed';
-  const [themeDrawerOpen, setThemeDrawerOpen] = React.useState(false);
-
   // Get navigation items based on current context
   const navSections = getSidebarNavItems(
     activeRole,
@@ -171,34 +157,6 @@ export function AppSidebar({ user, ...props }: AppSidebarProps) {
                   </div>
                 </DropdownMenuLabel>
                 <DropdownMenuSeparator />
-                <DropdownMenuGroup>
-                  <DropdownMenuItem asChild className="cursor-pointer">
-                    <Link href="/profile" onClick={() => setOpenMobile(false)}>
-                      <Settings className="mr-2 size-4" />
-                      Profile Settings
-                    </Link>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    className="cursor-pointer"
-                    onClick={() => setThemeDrawerOpen(true)}
-                  >
-                    <Palette className="mr-2 size-4" />
-                    Customize Theme
-                  </DropdownMenuItem>
-                  <DropdownMenuItem asChild className="cursor-pointer">
-                    <Link href="/help" onClick={() => setOpenMobile(false)}>
-                      <HelpCircle className="mr-2 size-4" />
-                      Help & Support
-                    </Link>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem asChild className="cursor-pointer">
-                    <Link href="/payments" onClick={() => setOpenMobile(false)}>
-                      <CreditCard className="mr-2 size-4" />
-                      Payments
-                    </Link>
-                  </DropdownMenuItem>
-                </DropdownMenuGroup>
-                <DropdownMenuSeparator />
                 <DropdownMenuItem
                   onClick={() => signOut({ callbackUrl: '/' })}
                   className="cursor-pointer text-destructive focus:text-destructive"
@@ -212,8 +170,6 @@ export function AppSidebar({ user, ...props }: AppSidebarProps) {
         </SidebarMenu>
       </SidebarFooter>
 
-      {/* Theme Customization Drawer */}
-      <ThemeDrawer open={themeDrawerOpen} onOpenChange={setThemeDrawerOpen} />
     </Sidebar>
   );
 }

--- a/src/components/app/role-switcher.tsx
+++ b/src/components/app/role-switcher.tsx
@@ -66,6 +66,7 @@ const roleConfigs: Record<Role, RoleConfig> = {
 // ============================================================================
 
 export function RoleSwitcher() {
+  const { data: session } = useSession();
   const { activeRole, availableRoles, setActiveRole, isLoading } = useRole();
   const { activeLeague } = useLeague();
   const router = useRouter();

--- a/src/contexts/league-context.tsx
+++ b/src/contexts/league-context.tsx
@@ -179,7 +179,7 @@ export function LeagueProvider({ children }: LeagueProviderProps) {
         // Always land in player/captain view when available
         const nextRole = preferredRole || highestAvailableRole;
 
-        if (savedRole && selectedLeague.roles.includes(savedRole as LeagueRole) && (savedRole === 'player' || savedRole === 'captain')) {
+        if (savedRole && selectedLeague.roles.includes(savedRole as LeagueRole)) {
           setCurrentRoleState(savedRole as LeagueRole);
         } else if (nextRole) {
           setCurrentRoleState(nextRole);
@@ -219,7 +219,7 @@ export function LeagueProvider({ children }: LeagueProviderProps) {
 
       const nextRole = preferredRole || highestAvailableRole;
 
-      if (savedRole && league.roles.includes(savedRole as LeagueRole) && (savedRole === 'player' || savedRole === 'captain')) {
+      if (savedRole && league.roles.includes(savedRole as LeagueRole)) {
         setCurrentRoleState(savedRole as LeagueRole);
       } else if (nextRole) {
         setCurrentRoleState(nextRole);

--- a/src/lib/navigation/sidebar-config.ts
+++ b/src/lib/navigation/sidebar-config.ts
@@ -18,6 +18,8 @@ import {
   FileText,
   LucideIcon,
   BookOpen,
+  HelpCircle,
+  CreditCard,
 } from 'lucide-react';
 
 // ============================================================================
@@ -62,7 +64,21 @@ const baseNavItems: NavItem[] = [
     url: '/leagues/join',
     icon: Search,
   },
-
+  {
+    title: 'Profile Settings',
+    url: '/profile',
+    icon: Settings,
+  },
+  {
+    title: 'Help & Support',
+    url: '/help',
+    icon: HelpCircle,
+  },
+  {
+    title: 'Payments',
+    url: '/payments',
+    icon: CreditCard,
+  },
 ];
 
 // ============================================================================

--- a/src/lib/services/teams.ts
+++ b/src/lib/services/teams.ts
@@ -5,6 +5,7 @@
  */
 import { getSupabaseServiceRole } from '@/lib/supabase/client';
 import { generateInviteCode } from './invites';
+import { getUserRoleInLeague } from './leagues';
 
 // ============================================================================
 // Types
@@ -740,14 +741,16 @@ export async function assignGovernor(
       return { success: false, error: 'User is not a member of this league' };
     }
 
-    // Check if user is host (cannot be governor too) - host is the league creator (created_by)
+    // Check if user is host (cannot be governor too)
     const { data: league } = await supabase
       .from('leagues')
       .select('created_by')
       .eq('league_id', leagueId)
       .single();
 
-    if (league?.created_by === userId) {
+    const isCreator = league?.created_by === userId;
+    const userRole = await getUserRoleInLeague(userId, leagueId);
+    if (isCreator || userRole === 'host') {
       return { success: false, error: 'Host cannot be assigned as governor' };
     }
 


### PR DESCRIPTION
## Summary
- **Critical: Submit page crash** — fixed infinite loop (activityDate in deps) + race condition (loading guard before access check)
- **Critical: Rest days from practice days** — added `.gte('date', league.start_date)` filter in rest-days API + auto-rest-day cron
- **Admin impersonation** — fixed Access Restricted (localStorage before redirect, role context accepts any role, API host checks via `checkIsHost` helper across activities, submissions, teams routes)
- **Configure Activities empty** — fixed host permission check to include assigned roles, not just `created_by`
- **Cron timezone** — changed offset from UTC to IST (5.5)
- **Settings defaults** — auto_rest_day=true, normalization=true, "Private League" always-on
- **Sidebar** — Profile Settings, Help & Support, Payments moved to sidebar nav; only Sign Out in dropdown
- **MyTeam** — removed max capacity from member count; added Rest Days Used + Days Missed stat cards
- **MyActivity Team Summary** — reduced to 3 cards: Total Points, Run Rate, Team Rank
- **League Information** — merged League Progress inside; highlighted Start/End dates; Rest Days box next to Days Total; removed Max Capacity + Schedule/Rest Days row

## Test plan
- [ ] Player: open submit page → should load without crash or infinite toasts
- [ ] Admin: Login as Host → should land on settings with full host access
- [ ] Admin-as-Host: open Configure Activities → should see all activities
- [ ] Check rest days count excludes practice period (before league start date)
- [ ] MyTeam: member count shows "11" not "11/20"; Rest Days Used + Days Missed cards visible
- [ ] MyActivity: Team Summary shows 3 cards only (Total Points, Run Rate, Team Rank)
- [ ] League Info: progress bar inside, dates highlighted, Rest Days next to Days Total, no max capacity

🤖 Generated with [Claude Code](https://claude.com/claude-code)