### PR TITLE
Add configurable proof/notes, points per session, multi-outcome support

### DIFF
--- a/src/app/(app)/leagues/[id]/activities/page.tsx
+++ b/src/app/(app)/leagues/[id]/activities/page.tsx
@@ -92,7 +92,7 @@ export default function LeagueActivitiesPage({
   const [openDescriptionId, setOpenDescriptionId] = React.useState<string | null>(null);
 
   // Track pending changes before saving
-  const [pendingChanges, setPendingChanges] = React.useState<Map<string, { enabled?: boolean; frequency?: number | null; frequency_type?: 'weekly' | 'monthly' | null; minimums?: { min_value: number | null; age_group_overrides: Record<string, any> } }>>(new Map());
+  const [pendingChanges, setPendingChanges] = React.useState<Map<string, { enabled?: boolean; frequency?: number | null; frequency_type?: 'weekly' | 'monthly' | null; minimums?: { min_value: number | null; age_group_overrides: Record<string, any> }; proof_requirement?: 'not_required' | 'optional' | 'mandatory'; notes_requirement?: 'not_required' | 'optional' | 'mandatory'; points_per_session?: number; outcome_config?: { label: string; points: number }[] | null }>>(new Map());
 
   const hasChanges = pendingChanges.size > 0;
   const toggleLoading = null;
@@ -332,6 +332,20 @@ export default function LeagueActivitiesPage({
     }
   };
 
+  const handleActivityConfigChange = (config: { activity_id: string; proof_requirement: 'not_required' | 'optional' | 'mandatory'; notes_requirement: 'not_required' | 'optional' | 'mandatory'; points_per_session: number }) => {
+    setPendingChanges((prev) => {
+      const next = new Map(prev);
+      const change = next.get(config.activity_id) || {};
+      next.set(config.activity_id, {
+        ...change,
+        proof_requirement: config.proof_requirement,
+        notes_requirement: config.notes_requirement,
+        points_per_session: config.points_per_session,
+      });
+      return next;
+    });
+  };
+
   const handleMinimumChange = (config: { activity_id: string; min_value: number | null; age_group_overrides: Record<string, any> }) => {
     setPendingChanges((prev) => {
       const next = new Map(prev);
@@ -352,39 +366,60 @@ export default function LeagueActivitiesPage({
 
     setIsSaving(true);
     try {
-      let successCount = 0;
-      let errorCount = 0;
+      // Build all promises in parallel, one set per activity
+      const promises: Promise<{ ok: boolean }>[] = [];
 
       for (const [activityId, change] of pendingChanges) {
-        try {
+        // Enable/disable must run first (sequentially per activity) since
+        // removing an activity means we skip its other updates.
+        // But different activities can run in parallel.
+        const activityPromise = (async (): Promise<{ ok: boolean }> => {
+          const results: boolean[] = [];
+
           if (change.enabled !== undefined) {
             const success = change.enabled
               ? await addActivities([activityId])
               : await removeActivity(activityId);
-            if (success) successCount++;
-            else errorCount++;
-            // If activity was removed, skip frequency/minimum updates
-            if (change.enabled === false) continue;
+            results.push(success);
+            if (change.enabled === false) return { ok: results.every(Boolean) };
           }
 
-          if (change.frequency !== undefined || change.frequency_type !== undefined) {
-            const nextFrequency = change.frequency !== undefined
-              ? change.frequency
-              : enabledActivityMap.get(activityId)?.frequency ?? null;
-            const nextFrequencyType = change.frequency_type !== undefined
-              ? change.frequency_type
-              : frequencyTypeDrafts[activityId]
-              ?? enabledActivityMap.get(activityId)?.frequency_type
-              ?? 'weekly';
+          // Fire PATCH and minimums in parallel for this activity
+          const subPromises: Promise<boolean>[] = [];
 
-            const success = await updateFrequency(activityId, nextFrequency, nextFrequencyType);
-            if (success) successCount++;
-            else errorCount++;
+          if (change.frequency !== undefined || change.frequency_type !== undefined
+              || change.proof_requirement !== undefined || change.notes_requirement !== undefined
+              || change.points_per_session !== undefined || change.outcome_config !== undefined) {
+            const patchBody: Record<string, any> = { activity_id: activityId };
+
+            if (change.frequency !== undefined || change.frequency_type !== undefined) {
+              patchBody.frequency = change.frequency !== undefined
+                ? change.frequency
+                : enabledActivityMap.get(activityId)?.frequency ?? null;
+              patchBody.frequency_type = change.frequency_type !== undefined
+                ? change.frequency_type
+                : frequencyTypeDrafts[activityId]
+                ?? enabledActivityMap.get(activityId)?.frequency_type
+                ?? 'weekly';
+            }
+
+            if (change.proof_requirement !== undefined) patchBody.proof_requirement = change.proof_requirement;
+            if (change.notes_requirement !== undefined) patchBody.notes_requirement = change.notes_requirement;
+            if (change.points_per_session !== undefined) patchBody.points_per_session = change.points_per_session;
+            if (change.outcome_config !== undefined) patchBody.outcome_config = change.outcome_config;
+
+            subPromises.push(
+              fetch(`/api/leagues/${leagueId}/activities`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(patchBody),
+              }).then(r => r.ok).catch(() => false)
+            );
           }
 
           if (change.minimums !== undefined) {
-            try {
-              const response = await fetch('/api/leagues/activity-minimums', {
+            subPromises.push(
+              fetch('/api/leagues/activity-minimums', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
@@ -394,20 +429,24 @@ export default function LeagueActivitiesPage({
                   min_value: change.minimums.min_value,
                   age_group_overrides: change.minimums.age_group_overrides,
                 }),
-              });
-              if (response.ok) successCount++;
-              else errorCount++;
-            } catch (err) {
-              errorCount++;
-            }
+              }).then(r => r.ok).catch(() => false)
+            );
           }
-        } catch (err) {
-          errorCount++;
-        }
+
+          const subResults = await Promise.all(subPromises);
+          results.push(...subResults);
+          return { ok: results.every(Boolean) };
+        })();
+
+        promises.push(activityPromise);
       }
 
+      const results = await Promise.all(promises);
+      const successCount = results.filter(r => r.ok).length;
+      const errorCount = results.filter(r => !r.ok).length;
+
       if (errorCount === 0) {
-        toast.success(`All ${successCount} changes saved successfully`);
+        toast.success(successCount === 1 ? 'Changes saved' : `All ${successCount} activities updated`);
         setPendingChanges(new Map());
       } else if (successCount > 0) {
         toast.error(`Saved ${successCount} changes, but ${errorCount} failed`);
@@ -783,6 +822,10 @@ export default function LeagueActivitiesPage({
                               onFrequencyChange={handleFrequencyChange}
                               onFrequencyTypeChange={handleFrequencyTypeChange}
                               onFrequencyBlur={handleFrequencyBlur}
+                              proofRequirement={enabledActivityMap.get(activity.activity_id)?.proof_requirement ?? 'mandatory'}
+                              notesRequirement={enabledActivityMap.get(activity.activity_id)?.notes_requirement ?? 'optional'}
+                              pointsPerSession={enabledActivityMap.get(activity.activity_id)?.points_per_session ?? 1}
+                              onActivityConfigChange={handleActivityConfigChange}
                             />
                           </div>
                         )}

--- a/src/app/(app)/leagues/[id]/submit/page.tsx
+++ b/src/app/(app)/leagues/[id]/submit/page.tsx
@@ -158,6 +158,7 @@ export default function SubmitActivityPage({
     steps: '',
     holes: '',
     notes: '',
+    outcome: '',
   });
 
   // Submission type tab state
@@ -361,6 +362,7 @@ export default function SubmitActivityPage({
         steps: stepsParam || '',
         holes: holesParam || '',
         notes: notesParam || '',
+        outcome: '',
       });
 
       toast.info('Resubmitting rejected workout. Update as needed.');
@@ -805,17 +807,23 @@ export default function SubmitActivityPage({
       }
     }
 
-    if (!selectedFile && !overwrite && !resubmitId) {
-      // If overwriting and proof_url exists on previous entry, backend might allow skipping upload?
-      // Logic in backend: "if type=workout and !proof_url and !(canReplaceRejected && existing.proof_url)..."
-      // If we are overwriting an APPROVED entry, does backend require new proof?
-      // Check backend: "if (type === 'workout' && !proof_url && !(canReplaceRejected && existing?.proof_url))"
-      // It seems it allows reuse ONLY if canReplaceRejected.
-      // So if overwriting an APPROVED entry, we might need a new proof OR allow existing.
-      // Current backend logic seems to demand proof_url unless replacing rejected.
-      // Let's demand proof for now to be safe, unless user explicitly didn't change it?
-      // For now, simplify: Always require proof for new submissions.
+    // Proof validation: respect per-activity proof_requirement
+    const proofReq = selectedActivity?.proof_requirement ?? 'mandatory';
+    if (proofReq === 'mandatory' && !selectedFile && !overwrite && !resubmitId) {
       toast.error('Proof screenshot is required');
+      return;
+    }
+
+    // Notes validation: respect per-activity notes_requirement
+    const notesReq = selectedActivity?.notes_requirement ?? 'optional';
+    if (notesReq === 'mandatory' && !formData.notes.trim()) {
+      toast.error('Notes are required for this activity');
+      return;
+    }
+
+    // Outcome validation: required when activity has outcome_config
+    if (selectedActivity?.outcome_config && selectedActivity.outcome_config.length > 0 && !formData.outcome) {
+      toast.error('Please select an outcome');
       return;
     }
 
@@ -880,6 +888,11 @@ export default function SubmitActivityPage({
       // Add notes if provided
       if (formData.notes) {
         payload.notes = formData.notes;
+      }
+
+      // Add outcome if selected
+      if (formData.outcome) {
+        payload.outcome = formData.outcome;
       }
 
       // Add reupload_of if this is a resubmission
@@ -1115,6 +1128,7 @@ export default function SubmitActivityPage({
       steps: '',
       holes: '',
       notes: '',
+      outcome: '',
     });
     setSelectedFile(null);
     setImagePreview(null);
@@ -1315,9 +1329,12 @@ export default function SubmitActivityPage({
                 </div>
               </div>
 
-              {/* Photo Upload */}
+              {/* Photo Upload — hidden when proof_requirement is 'not_required' */}
+              {(selectedActivity?.proof_requirement ?? 'mandatory') !== 'not_required' && (
               <div className="space-y-2">
-                <Label htmlFor="proof-file">Upload Proof (Required for approval) *</Label>
+                <Label htmlFor="proof-file">
+                  Upload Proof{(selectedActivity?.proof_requirement ?? 'mandatory') === 'mandatory' ? ' *' : ' (Optional)'}
+                </Label>
                 <input
                   id="proof-file"
                   ref={fileInputRef}
@@ -1360,13 +1377,39 @@ export default function SubmitActivityPage({
                   </div>
                 )}
               </div>
+              )}
 
-              {/* Notes */}
+              {/* Outcome picker — shown when activity has outcome_config */}
+              {selectedActivity?.outcome_config && selectedActivity.outcome_config.length > 0 && (
               <div className="space-y-2">
-                <Label htmlFor="notes">Notes (Optional)</Label>
+                <Label>Outcome *</Label>
+                <Select
+                  value={formData.outcome || ''}
+                  onValueChange={(v) => setFormData((prev) => ({ ...prev, outcome: v }))}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select outcome" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {selectedActivity.outcome_config.map((o) => (
+                      <SelectItem key={o.label} value={o.label}>
+                        {o.label} ({o.points} pt{o.points !== 1 ? 's' : ''})
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              )}
+
+              {/* Notes — hidden when notes_requirement is 'not_required' */}
+              {(selectedActivity?.notes_requirement ?? 'optional') !== 'not_required' && (
+              <div className="space-y-2">
+                <Label htmlFor="notes">
+                  Notes{(selectedActivity?.notes_requirement) === 'mandatory' ? ' *' : ' (Optional)'}
+                </Label>
                 <Textarea
                   id="notes"
-                  placeholder="Share a quick note (optional)"
+                  placeholder={selectedActivity?.notes_requirement === 'mandatory' ? 'Notes are required for this activity' : 'Share a quick note (optional)'}
                   rows={2}
                   value={formData.notes}
                   onChange={(e) =>
@@ -1374,6 +1417,7 @@ export default function SubmitActivityPage({
                   }
                 />
               </div>
+              )}
 
               {/* Summary and Submit */}
               <div className="pt-4 border-t space-y-4">
@@ -1396,7 +1440,7 @@ export default function SubmitActivityPage({
                   <Button
                     type="submit"
                     className="flex-1"
-                    disabled={loading || uploadingImage || !formData.activity_type || !selectedFile}
+                    disabled={loading || uploadingImage || !formData.activity_type || ((selectedActivity?.proof_requirement ?? 'mandatory') === 'mandatory' && !selectedFile)}
                   >
                     {loading || uploadingImage ? (
                       <>

--- a/src/app/api/entries/upsert/route.ts
+++ b/src/app/api/entries/upsert/route.ts
@@ -26,6 +26,7 @@ interface EntryPayload {
   rr_value?: number;
   proof_url?: string;
   notes?: string;
+  outcome?: string | null;
   status: 'pending' | 'approved' | 'rejected';
   created_by: string;
   reupload_of?: string | null;
@@ -58,6 +59,7 @@ export async function POST(req: NextRequest) {
       proof_url,
       notes,
       reupload_of,
+      outcome, // Selected outcome label for multi-outcome activities (e.g., "Win", "Loss")
       timezone_offset, // Legacy: sign-inverted offset (e.g., +330 for IST = UTC+5:30)
       tzOffsetMinutes, // Preferred: same value as `new Date().getTimezoneOffset()` (e.g., -330 for IST)
       ianaTimezone, // Preferred IANA tz (e.g., 'America/Los_Angeles')
@@ -363,16 +365,80 @@ export async function POST(req: NextRequest) {
     const hasNonRejected = (existingRows ?? []).some((r: any) => r?.status && r.status !== 'rejected');
     const canReplaceRejected = !!existing && !hasNonRejected;
 
-    // Proof screenshot is mandatory for workout entries.
-    // Allow updates without a new proof_url only if an existing proof_url is already present.
-    if (type === 'workout' && !proof_url && !(canReplaceRejected && existing?.proof_url)) {
+    // Look up per-activity proof/notes/points configuration from leagueactivities
+    let activityProofRequirement: 'not_required' | 'optional' | 'mandatory' = 'mandatory';
+    let activityNotesRequirement: 'not_required' | 'optional' | 'mandatory' = 'optional';
+    let activityPointsPerSession: number = 1;
+    let activityOutcomeConfig: { label: string; points: number }[] | null = null;
+
+    if (type === 'workout' && workout_type) {
+      const isUuidWorkoutType = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(workout_type);
+
+      let activityConfigRow: any = null;
+
+      if (isUuidWorkoutType) {
+        // Custom activity — lookup by custom_activity_id
+        const { data, error } = await supabase
+          .from('leagueactivities')
+          .select('proof_requirement, notes_requirement, points_per_session, outcome_config')
+          .eq('league_id', league_id)
+          .eq('custom_activity_id', workout_type)
+          .maybeSingle();
+        // If new columns don't exist yet (pre-migration), ignore the error and use defaults
+        if (!error) activityConfigRow = data;
+      }
+
+      if (!activityConfigRow) {
+        // Global activity — lookup by activity name via join
+        const { data, error } = await supabase
+          .from('leagueactivities')
+          .select('proof_requirement, notes_requirement, points_per_session, outcome_config, activities!inner(activity_name)')
+          .eq('league_id', league_id)
+          .eq('activities.activity_name', workout_type)
+          .maybeSingle();
+        if (!error) activityConfigRow = data;
+      }
+
+      if (activityConfigRow) {
+        activityProofRequirement = activityConfigRow.proof_requirement ?? 'mandatory';
+        activityNotesRequirement = activityConfigRow.notes_requirement ?? 'optional';
+        activityPointsPerSession = activityConfigRow.points_per_session ?? 1;
+        activityOutcomeConfig = activityConfigRow.outcome_config ?? null;
+      }
+    }
+
+    // Proof validation: respect per-activity proof_requirement config
+    if (type === 'workout' && activityProofRequirement === 'mandatory' && !proof_url && !(canReplaceRejected && existing?.proof_url)) {
       return NextResponse.json(
         { error: 'proof_url is required for workout entries' },
         { status: 400 }
       );
     }
 
-    // Reupload count removed from system; we only link to the original via reupload_of.
+    // Notes validation: respect per-activity notes_requirement config
+    if (type === 'workout' && activityNotesRequirement === 'mandatory' && !notes) {
+      return NextResponse.json(
+        { error: 'Notes are required for this activity' },
+        { status: 400 }
+      );
+    }
+
+    // Validate outcome if activity has outcome_config
+    if (type === 'workout' && activityOutcomeConfig && activityOutcomeConfig.length > 0) {
+      if (!outcome) {
+        return NextResponse.json(
+          { error: 'An outcome selection is required for this activity' },
+          { status: 400 }
+        );
+      }
+      const validLabels = activityOutcomeConfig.map((o: any) => o.label);
+      if (!validLabels.includes(outcome)) {
+        return NextResponse.json(
+          { error: `Invalid outcome. Must be one of: ${validLabels.join(', ')}` },
+          { status: 400 }
+        );
+      }
+    }
 
     // Build entry payload
     const payload: EntryPayload = {
@@ -386,6 +452,7 @@ export async function POST(req: NextRequest) {
       holes: holes || null,
       proof_url: proof_url || null,
       notes: notes || null,
+      outcome: outcome || null,
       status: 'approved',
       created_by: userId,
       reupload_of: reupload_of || null,

--- a/src/app/api/leagues/[id]/activities/route.ts
+++ b/src/app/api/leagues/[id]/activities/route.ts
@@ -61,6 +61,11 @@ export interface LeagueActivity {
   custom_activity_id?: string;
   requires_proof?: boolean;
   requires_notes?: boolean;
+  // Per-league activity configuration
+  proof_requirement?: 'not_required' | 'optional' | 'mandatory';
+  notes_requirement?: 'not_required' | 'optional' | 'mandatory';
+  points_per_session?: number;
+  outcome_config?: { label: string; points: number }[] | null;
 }
 
 // ============================================================================
@@ -92,10 +97,14 @@ export async function PATCH(
     }
 
     const body = await request.json();
-    const { activity_id, frequency, frequency_type } = body as {
+    const { activity_id, frequency, frequency_type, proof_requirement, notes_requirement, points_per_session, outcome_config } = body as {
       activity_id?: string;
       frequency?: number | null;
       frequency_type?: 'weekly' | 'monthly' | null;
+      proof_requirement?: 'not_required' | 'optional' | 'mandatory';
+      notes_requirement?: 'not_required' | 'optional' | 'mandatory';
+      points_per_session?: number;
+      outcome_config?: { label: string; points: number }[] | null;
     };
 
     if (!activity_id) {
@@ -107,10 +116,14 @@ export async function PATCH(
 
     const hasFrequency = Object.prototype.hasOwnProperty.call(body, 'frequency');
     const hasFrequencyType = Object.prototype.hasOwnProperty.call(body, 'frequency_type');
+    const hasProofRequirement = Object.prototype.hasOwnProperty.call(body, 'proof_requirement');
+    const hasNotesRequirement = Object.prototype.hasOwnProperty.call(body, 'notes_requirement');
+    const hasPointsPerSession = Object.prototype.hasOwnProperty.call(body, 'points_per_session');
+    const hasOutcomeConfig = Object.prototype.hasOwnProperty.call(body, 'outcome_config');
 
-    if (!hasFrequency && !hasFrequencyType) {
+    if (!hasFrequency && !hasFrequencyType && !hasProofRequirement && !hasNotesRequirement && !hasPointsPerSession && !hasOutcomeConfig) {
       return NextResponse.json(
-        { error: 'frequency or frequency_type is required' },
+        { error: 'At least one field to update is required' },
         { status: 400 }
       );
     }
@@ -184,6 +197,71 @@ export async function PATCH(
 
     if (hasFrequencyType) {
       updatePayload.frequency_type = normalizedFrequencyType ?? 'weekly';
+    }
+
+    // Handle proof_requirement
+    if (hasProofRequirement) {
+      const validValues = ['not_required', 'optional', 'mandatory'];
+      if (!validValues.includes(proof_requirement as string)) {
+        return NextResponse.json(
+          { error: 'proof_requirement must be not_required, optional, or mandatory' },
+          { status: 400 }
+        );
+      }
+      updatePayload.proof_requirement = proof_requirement;
+    }
+
+    // Handle notes_requirement
+    if (hasNotesRequirement) {
+      const validValues = ['not_required', 'optional', 'mandatory'];
+      if (!validValues.includes(notes_requirement as string)) {
+        return NextResponse.json(
+          { error: 'notes_requirement must be not_required, optional, or mandatory' },
+          { status: 400 }
+        );
+      }
+      updatePayload.notes_requirement = notes_requirement;
+    }
+
+    // Handle points_per_session
+    if (hasPointsPerSession) {
+      const pts = Number(points_per_session);
+      if (!Number.isFinite(pts) || pts < 0) {
+        return NextResponse.json(
+          { error: 'points_per_session must be a non-negative number' },
+          { status: 400 }
+        );
+      }
+      updatePayload.points_per_session = pts;
+    }
+
+    // Handle outcome_config
+    if (hasOutcomeConfig) {
+      if (outcome_config === null) {
+        updatePayload.outcome_config = null;
+      } else if (Array.isArray(outcome_config)) {
+        // Validate each outcome entry
+        for (const item of outcome_config) {
+          if (!item.label || typeof item.label !== 'string') {
+            return NextResponse.json(
+              { error: 'Each outcome must have a label string' },
+              { status: 400 }
+            );
+          }
+          if (typeof item.points !== 'number' || !Number.isFinite(item.points)) {
+            return NextResponse.json(
+              { error: 'Each outcome must have a numeric points value' },
+              { status: 400 }
+            );
+          }
+        }
+        updatePayload.outcome_config = outcome_config;
+      } else {
+        return NextResponse.json(
+          { error: 'outcome_config must be an array or null' },
+          { status: 400 }
+        );
+      }
     }
 
     const { data: updated, error: updateError } = await supabase
@@ -310,9 +388,13 @@ export async function GET(
         frequency_type,
         min_value,
         age_group_overrides,
+        proof_requirement,
+        notes_requirement,
+        points_per_session,
+        outcome_config,
         activities(
-          activity_id, 
-          activity_name, 
+          activity_id,
+          activity_name,
           description,
           category_id,
           measurement_type,
@@ -334,7 +416,38 @@ export async function GET(
     leagueActivities = withFrequency.data as any[] | null;
     activitiesError = withFrequency.error;
 
-    // Fallback if frequency/frequency_type columns are not present yet
+    // Fallback if new columns are not present yet (pre-migration)
+    if (activitiesError && typeof activitiesError?.message === 'string') {
+      const msg = activitiesError.message.toLowerCase();
+
+      // Fallback: if proof_requirement/notes_requirement/points_per_session/outcome_config columns don't exist
+      if ((msg.includes('proof_requirement') || msg.includes('notes_requirement') || msg.includes('points_per_session') || msg.includes('outcome_config')) && msg.includes('column')) {
+        const withoutNewCols = await supabase
+          .from('leagueactivities')
+          .select(`
+            activity_id,
+            custom_activity_id,
+            frequency,
+            frequency_type,
+            min_value,
+            age_group_overrides,
+            activities(
+              activity_id, activity_name, description, category_id, measurement_type, settings, admin_info,
+              activity_categories(category_id, category_name, display_name)
+            ),
+            custom_activities(
+              custom_activity_id, activity_name, description, measurement_type, requires_proof, requires_notes
+            )
+          `)
+          .eq('league_id', leagueId);
+
+        leagueActivities = withoutNewCols.data as any[] | null;
+        activitiesError = withoutNewCols.error;
+      }
+
+    }
+
+    // Further fallback for frequency columns (may happen after new-column fallback or independently)
     if (activitiesError && typeof activitiesError?.message === 'string') {
       const msg = activitiesError.message.toLowerCase();
       if (msg.includes('frequency_type') && msg.includes('column')) {
@@ -437,6 +550,10 @@ export async function GET(
             is_custom: true,
             requires_proof: customAct.requires_proof,
             requires_notes: customAct.requires_notes,
+            proof_requirement: (la as any).proof_requirement ?? 'mandatory',
+            notes_requirement: (la as any).notes_requirement ?? 'optional',
+            points_per_session: (la as any).points_per_session ?? 1,
+            outcome_config: (la as any).outcome_config ?? null,
           };
         }
 
@@ -457,6 +574,10 @@ export async function GET(
           settings: activity.settings,
           admin_info: activity.admin_info,
           is_custom: false,
+          proof_requirement: (la as any).proof_requirement ?? 'mandatory',
+          notes_requirement: (la as any).notes_requirement ?? 'optional',
+          points_per_session: (la as any).points_per_session ?? 1,
+          outcome_config: (la as any).outcome_config ?? null,
         };
       });
 

--- a/src/app/api/leagues/[id]/leaderboard/route.ts
+++ b/src/app/api/leagues/[id]/leaderboard/route.ts
@@ -279,7 +279,7 @@ export async function GET(
     // =========================================================================
     let entriesQuery = supabase
       .from('effortentry')
-      .select('id, league_member_id, date, type, rr_value, status')
+      .select('id, league_member_id, date, type, workout_type, outcome, rr_value, status')
       .in('league_member_id', memberIds);
 
     // Apply start bound:
@@ -295,12 +295,73 @@ export async function GET(
     // Always apply the delayed end bound.
     entriesQuery = entriesQuery.lte('date', effectiveEndDate);
 
-    const { data: entries, error: entriesError } = await entriesQuery;
+    let { data: entries, error: entriesError } = await entriesQuery;
+
+    // Fallback if 'outcome' or 'workout_type' columns don't exist yet
+    if (entriesError && typeof entriesError?.message === 'string' && entriesError.message.toLowerCase().includes('column')) {
+      const fallbackQuery = supabase
+        .from('effortentry')
+        .select('id, league_member_id, date, type, rr_value, status')
+        .in('league_member_id', memberIds);
+      if (startDate) fallbackQuery.gte('date', startDate);
+      else fallbackQuery.gte('date', league.start_date);
+      fallbackQuery.lte('date', effectiveEndDate);
+      const fallback = await fallbackQuery;
+      entries = fallback.data;
+      entriesError = fallback.error;
+    }
 
     if (entriesError) {
       console.error('Error fetching entries:', entriesError);
       return NextResponse.json({ error: 'Failed to fetch entries' }, { status: 500 });
     }
+
+    // =========================================================================
+    // Fetch activity points configuration for this league
+    // =========================================================================
+    let activityConfigRows: any[] | null = null;
+    const configResult = await supabase
+      .from('leagueactivities')
+      .select('activity_id, custom_activity_id, points_per_session, outcome_config, activities(activity_name)')
+      .eq('league_id', leagueId);
+    if (!configResult.error) {
+      activityConfigRows = configResult.data;
+    } else {
+      // Fallback if points_per_session/outcome_config columns don't exist yet (pre-migration)
+      const fallback = await supabase
+        .from('leagueactivities')
+        .select('activity_id, custom_activity_id, activities(activity_name)')
+        .eq('league_id', leagueId);
+      activityConfigRows = fallback.data;
+    }
+
+    // Build lookup maps: activity_name -> config, custom_activity_id -> config
+    const activityPointsMap = new Map<string, { points_per_session: number; outcome_config: any[] | null }>();
+    for (const row of (activityConfigRows || [])) {
+      const config = {
+        points_per_session: (row as any).points_per_session ?? 1,
+        outcome_config: (row as any).outcome_config ?? null,
+      };
+      if ((row as any).activities?.activity_name) {
+        activityPointsMap.set((row as any).activities.activity_name, config);
+      }
+      if (row.custom_activity_id) {
+        activityPointsMap.set(row.custom_activity_id, config);
+      }
+    }
+
+    // Helper to resolve points for an entry
+    const getEntryPoints = (entry: any): number => {
+      if (!entry.workout_type) return 1;
+      const config = activityPointsMap.get(entry.workout_type);
+      if (!config) return 1;
+      // If outcome_config exists and entry has an outcome, use outcome-specific points
+      if (config.outcome_config && Array.isArray(config.outcome_config) && entry.outcome) {
+        const outcomeMatch = config.outcome_config.find((o: any) => o.label === entry.outcome);
+        if (outcomeMatch) return outcomeMatch.points;
+      }
+      return config.points_per_session;
+    };
 
     // =========================================================================
     // Fetch pending-window effort entries (today/yesterday), excluded from main due to delay
@@ -617,7 +678,7 @@ export async function GET(
         const unique = uniqueEntriesMap.get(key);
         // Only count if THIS entry is the unique one (by ID)
         if (unique && unique.id === entry.id) {
-          teamStat.points++;
+          teamStat.points += getEntryPoints(entry);
 
           if (entry.rr_value && entry.rr_value > 0) {
             teamStat.total_rr += entry.rr_value;
@@ -687,7 +748,7 @@ export async function GET(
 
         const teamDateMap = pointsByTeamDate.get(teamId);
         if (!teamDateMap) continue;
-        teamDateMap.set(entry.date, (teamDateMap.get(entry.date) || 0) + 1);
+        teamDateMap.set(entry.date, (teamDateMap.get(entry.date) || 0) + getEntryPoints(entry));
 
         if (entry.rr_value && entry.rr_value > 0) {
           const agg = rrAggByTeam.get(teamId) || { total_rr: 0, rr_count: 0 };
@@ -777,7 +838,7 @@ export async function GET(
         const unique = uniqueEntriesMap.get(key);
 
         if (unique && unique.id === entry.id) {
-          individualStat.points++;
+          individualStat.points += getEntryPoints(entry);
 
           if (entry.rr_value && entry.rr_value > 0) {
             individualStat.total_rr += entry.rr_value;

--- a/src/components/leagues/activity-minimum-dropdown.tsx
+++ b/src/components/leagues/activity-minimum-dropdown.tsx
@@ -58,6 +58,9 @@ interface ActivityMinimumProps {
     max_value: number | null;
     age_group_overrides: Record<string, any>;
   };
+  proofRequirement?: 'not_required' | 'optional' | 'mandatory';
+  notesRequirement?: 'not_required' | 'optional' | 'mandatory';
+  pointsPerSession?: number;
   onMinimumChange?: (config: {
     activity_id: string;
     min_value: number | null;
@@ -66,6 +69,12 @@ interface ActivityMinimumProps {
   onFrequencyChange?: (activityId: string, frequency: string) => void;
   onFrequencyTypeChange?: (activityId: string, frequencyType: 'weekly' | 'monthly') => void;
   onFrequencyBlur?: (activityId: string) => void;
+  onActivityConfigChange?: (config: {
+    activity_id: string;
+    proof_requirement: 'not_required' | 'optional' | 'mandatory';
+    notes_requirement: 'not_required' | 'optional' | 'mandatory';
+    points_per_session: number;
+  }) => void;
 }
 
 export function ActivityMinimumDropdown({
@@ -77,13 +86,17 @@ export function ActivityMinimumDropdown({
   frequencyType,
   supportsFrequency = true,
   initialConfig,
+  proofRequirement = 'mandatory',
+  notesRequirement = 'optional',
+  pointsPerSession = 1,
   onMinimumChange,
   onFrequencyChange,
   onFrequencyTypeChange,
+  onActivityConfigChange,
 }: ActivityMinimumProps) {
   const unit = getUnitLabel(measurementType);
   const [isExpanded, setIsExpanded] = useState(false);
-  
+
   const [baseMin, setBaseMin] = useState<number | null>(initialConfig?.min_value ?? null);
   const [ageOverrides, setAgeOverrides] = useState<AgeOverride[]>(
     parseAgeOverrides(initialConfig?.age_group_overrides || {})
@@ -94,6 +107,9 @@ export function ActivityMinimumDropdown({
   const [frequencyTypeDraft, setFrequencyTypeDraft] = useState<'weekly' | 'monthly'>(
     frequencyType ?? 'weekly'
   );
+  const [proofDraft, setProofDraft] = useState<'not_required' | 'optional' | 'mandatory'>(proofRequirement);
+  const [notesDraft, setNotesDraft] = useState<'not_required' | 'optional' | 'mandatory'>(notesRequirement);
+  const [pointsDraft, setPointsDraft] = useState<number>(pointsPerSession);
 
   // Sync state with initialConfig when it changes
   useEffect(() => {
@@ -111,6 +127,10 @@ export function ActivityMinimumDropdown({
   useEffect(() => {
     setFrequencyTypeDraft(frequencyType ?? 'weekly');
   }, [frequencyType]);
+
+  useEffect(() => { setProofDraft(proofRequirement); }, [proofRequirement]);
+  useEffect(() => { setNotesDraft(notesRequirement); }, [notesRequirement]);
+  useEffect(() => { setPointsDraft(pointsPerSession); }, [pointsPerSession]);
 
   useEffect(() => {
     if (frequencyDraft === '') return;
@@ -190,6 +210,14 @@ export function ActivityMinimumDropdown({
         activity_id: activityId,
         min_value: baseMin,
         age_group_overrides: buildAgeGroupOverrides(),
+      });
+    }
+    if (onActivityConfigChange) {
+      onActivityConfigChange({
+        activity_id: activityId,
+        proof_requirement: proofDraft,
+        notes_requirement: notesDraft,
+        points_per_session: pointsDraft,
       });
     }
     setIsExpanded(false);
@@ -380,6 +408,50 @@ export function ActivityMinimumDropdown({
                 ))}
               </div>
             )}
+          </div>
+
+          {/* Proof, Notes & Points */}
+          <div className="space-y-2 border-t pt-3">
+            <h4 className="text-xs font-semibold">Submission Settings</h4>
+            <div className="grid grid-cols-2 gap-2">
+              <div>
+                <Label className="text-[10px] text-muted-foreground uppercase">Proof</Label>
+                <Select value={proofDraft} onValueChange={(v) => setProofDraft(v as any)}>
+                  <SelectTrigger className="h-7 text-xs">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="mandatory">Required</SelectItem>
+                    <SelectItem value="optional">Optional</SelectItem>
+                    <SelectItem value="not_required">Not needed</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label className="text-[10px] text-muted-foreground uppercase">Notes</Label>
+                <Select value={notesDraft} onValueChange={(v) => setNotesDraft(v as any)}>
+                  <SelectTrigger className="h-7 text-xs">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="mandatory">Required</SelectItem>
+                    <SelectItem value="optional">Optional</SelectItem>
+                    <SelectItem value="not_required">Not needed</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            <div>
+              <Label className="text-[10px] text-muted-foreground uppercase">Points per session</Label>
+              <Input
+                type="number"
+                min={0}
+                step={0.5}
+                className="h-7 text-xs"
+                value={pointsDraft}
+                onChange={(e) => setPointsDraft(e.target.value === '' ? 0 : Number(e.target.value))}
+              />
+            </div>
           </div>
 
           {/* Save button */}

--- a/src/hooks/use-league-activities.ts
+++ b/src/hooks/use-league-activities.ts
@@ -36,6 +36,11 @@ export interface LeagueActivity {
   custom_activity_id?: string;
   requires_proof?: boolean;
   requires_notes?: boolean;
+  // Per-league activity configuration
+  proof_requirement?: 'not_required' | 'optional' | 'mandatory';
+  notes_requirement?: 'not_required' | 'optional' | 'mandatory';
+  points_per_session?: number;
+  outcome_config?: { label: string; points: number }[] | null;
 }
 
 export interface LeagueActivitiesData {


### PR DESCRIPTION
## Summary
- Host can configure per-activity: proof (required/optional/not needed), notes (required/optional/not needed), points per session
- Multi-outcome activities (e.g., Win/Loss/Draw with different point values)
- Leaderboard uses configurable points instead of hardcoded 1 per entry
- Submit page conditionally shows/hides proof and notes fields
- Graceful fallbacks if migration hasn't run yet

## Migration Required
Run `backup/migration-activity-customization.sql` in Supabase SQL Editor (already done).

## Test plan
- [ ] Open host activities config → Configure an activity → verify Submission Settings section (Proof, Notes, Points)
- [ ] Change proof to Optional → submit page should allow submission without photo
- [ ] Change notes to Required → submit page should block submission without notes
- [ ] Change points to 2 → leaderboard should reflect 2 points per approved entry
- [ ] Verify existing activities with default config still work as before