### PR TITLE
Fix leaderboard truncation, points mismatch, and UI fixes

### DIFF
--- a/src/app/(app)/leagues/[id]/configure-challenges/page.tsx
+++ b/src/app/(app)/leagues/[id]/configure-challenges/page.tsx
@@ -1043,6 +1043,7 @@ export default function ConfigureChallengesPage({ params }: { params: Promise<{ 
                                 onChange={(e) => setSelectedFile(e.target.files?.[0] || null)}
                             />
                         </div>
+                        {createForm.challengeType === 'individual' && (
                         <div className="flex items-center gap-2">
                             <input
                                 type="checkbox"
@@ -1058,6 +1059,7 @@ export default function ConfigureChallengesPage({ params }: { params: Promise<{ 
                                 </span>
                             </Label>
                         </div>
+                        )}
                         <DialogFooter>
                             <Button type="button" variant="outline" onClick={() => setCreateOpen(false)}>Cancel</Button>
                             <Button type="submit">Save</Button>
@@ -1109,6 +1111,7 @@ export default function ConfigureChallengesPage({ params }: { params: Promise<{ 
                                     />
                                 </div>
                             </div>
+                            {selectedPreset?.challenge_type === 'individual' && (
                             <div className="flex items-center gap-2">
                                 <input
                                     type="checkbox"
@@ -1124,6 +1127,7 @@ export default function ConfigureChallengesPage({ params }: { params: Promise<{ 
                                     </span>
                                 </Label>
                             </div>
+                            )}
                         </div>
                     )}
                     <DialogFooter>

--- a/src/app/(app)/leagues/[id]/page.tsx
+++ b/src/app/(app)/leagues/[id]/page.tsx
@@ -534,14 +534,22 @@ export default function LeagueDashboardPage({
           const approvedSubs = subs.filter((s) => isApproved(s));
           console.log('[MySummary] Approved submissions:', approvedSubs);
 
-          // User-facing definitions for the dashboard:
-          // - Points: approved workouts count (1 point per approved workout)
-          // - Avg RR: total approved RR divided by the number of approved workout-days (points)
-          // BACKEND PARITY: All approved entries (workouts + rest) count as 1 point.
-          points = approvedSubs.length;
-          restUsed = approvedSubs.filter((s) => String(s.type).toLowerCase() === 'rest').length;
+          // Deduplicate: only one approved entry per date counts (matches leaderboard logic).
+          // If multiple approved entries exist on the same date (e.g. reupload), keep the one with RR.
+          const uniqueByDate = new Map<string, (typeof approvedSubs)[number]>();
+          approvedSubs.forEach((s) => {
+            const dateKey = String(s.date).slice(0, 10);
+            const existing = uniqueByDate.get(dateKey);
+            if (!existing || (!existing.rr_value && s.rr_value)) {
+              uniqueByDate.set(dateKey, s);
+            }
+          });
+          const dedupedApproved = Array.from(uniqueByDate.values());
 
-          const totalRR = approvedSubs
+          points = dedupedApproved.length;
+          restUsed = dedupedApproved.filter((s) => String(s.type).toLowerCase() === 'rest').length;
+
+          const totalRR = dedupedApproved
             .map((s) => {
               // User Rule: Rest days give 1 RR
               if (String(s.type).toLowerCase() === 'rest') return 1;
@@ -1415,8 +1423,8 @@ export default function LeagueDashboardPage({
             </div>
           )}
 
-          {/* Key stats */}
-          <div className="grid grid-cols-2 md:grid-cols-3 divide-x divide-y md:divide-y-0">
+          {/* Key stats — mobile: 3 rows × 2 cols, tablet/desktop: 2 rows × 3 cols */}
+          <div className="grid grid-cols-2 md:grid-cols-3 divide-x border-b">
             <div className="p-4 flex flex-col items-center text-center">
               <div className="size-10 rounded-lg bg-primary/10 flex items-center justify-center mb-2">
                 <Calendar className="size-5 text-primary" />
@@ -1424,43 +1432,40 @@ export default function LeagueDashboardPage({
               <p className="text-sm font-bold text-primary tabular-nums">{formatDate(league.start_date)}</p>
               <p className="text-xs text-muted-foreground">Start Date</p>
             </div>
-            <div className="p-4 flex flex-col items-center text-center">
+            <div className="p-4 flex flex-col items-center text-center border-b md:border-b-0">
               <div className="size-10 rounded-lg bg-primary/10 flex items-center justify-center mb-2">
                 <Calendar className="size-5 text-primary" />
               </div>
               <p className="text-sm font-bold text-primary tabular-nums">{formatDate(league.end_date)}</p>
               <p className="text-xs text-muted-foreground">End Date</p>
             </div>
-            <div className="p-4 flex flex-col items-center text-center">
+            <div className="p-4 flex flex-col items-center text-center border-b md:border-b-0">
               <div className="size-10 rounded-lg bg-primary/10 flex items-center justify-center mb-2">
                 <Timer className="size-5 text-primary" />
               </div>
               <p className="text-2xl font-bold tabular-nums">{totalDays}</p>
               <p className="text-xs text-muted-foreground">Days Total</p>
             </div>
-          </div>
-
-          <div className="grid grid-cols-3 divide-x border-t">
-            <div className="p-4 flex flex-col items-center text-center">
+            <div className="p-4 flex flex-col items-center text-center md:border-t">
+              <div className="size-10 rounded-lg bg-primary/10 flex items-center justify-center mb-2">
+                <Moon className="size-5 text-primary" />
+              </div>
+              <p className="text-2xl font-bold tabular-nums">{league.rest_days}</p>
+              <p className="text-xs text-muted-foreground">Rest Days</p>
+            </div>
+            <div className="p-4 flex flex-col items-center text-center border-t">
               <div className="size-10 rounded-lg bg-primary/10 flex items-center justify-center mb-2">
                 <Users className="size-5 text-primary" />
               </div>
               <p className="text-2xl font-bold tabular-nums">{league.member_count ?? 0}</p>
               <p className="text-xs text-muted-foreground">Players</p>
             </div>
-            <div className="p-4 flex flex-col items-center text-center">
+            <div className="p-4 flex flex-col items-center text-center border-t">
               <div className="size-10 rounded-lg bg-primary/10 flex items-center justify-center mb-2">
                 <Shield className="size-5 text-primary" />
               </div>
               <p className="text-2xl font-bold tabular-nums">{league.num_teams || 0}</p>
               <p className="text-xs text-muted-foreground">Teams</p>
-            </div>
-            <div className="p-4 flex flex-col items-center text-center">
-              <div className="size-10 rounded-lg bg-primary/10 flex items-center justify-center mb-2">
-                <Moon className="size-5 text-primary" />
-              </div>
-              <p className="text-2xl font-bold tabular-nums">{league.rest_days}</p>
-              <p className="text-xs text-muted-foreground">Rest Days</p>
             </div>
           </div>
 

--- a/src/app/(app)/leagues/[id]/submit/page.tsx
+++ b/src/app/(app)/leagues/[id]/submit/page.tsx
@@ -1645,11 +1645,9 @@ export default function SubmitActivityPage({
                   <span className="font-medium">{confirmActivityLabel}</span>
                 </div>
 
-                <div>
-                  <span className="text-muted-foreground block text-xs">Measurement</span>
-                  {confirmMeasurementType === 'none' ? (
-                    <span className="font-medium">None required</span>
-                  ) : confirmMetrics.length > 0 ? (
+                {confirmMeasurementType !== 'none' && confirmMetrics.length > 0 && (
+                  <div>
+                    <span className="text-muted-foreground block text-xs">Measurement</span>
                     <div className="grid grid-cols-2 gap-x-4 gap-y-2 mt-1">
                       {confirmMetrics.map((metric) => (
                         <div key={metric.label}>
@@ -1658,29 +1656,33 @@ export default function SubmitActivityPage({
                         </div>
                       ))}
                     </div>
-                  ) : (
-                    <span className="font-medium">Not provided</span>
-                  )}
-                </div>
+                  </div>
+                )}
 
-                <div>
-                  <span className="text-muted-foreground block text-xs">Notes</span>
-                  <span className="font-medium">{confirmNotes}</span>
-                </div>
+                {(selectedActivity?.notes_requirement ?? 'optional') !== 'not_required' && confirmNotes !== '—' && (
+                  <div>
+                    <span className="text-muted-foreground block text-xs">Notes</span>
+                    <span className="font-medium">{confirmNotes}</span>
+                  </div>
+                )}
 
-                <div>
-                  <span className="text-muted-foreground block text-xs">Upload Proof (Required for approval)</span>
-                  {imagePreview ? (
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img
-                      src={imagePreview}
-                      alt="Proof screenshot preview"
-                      className="mt-2 h-28 w-full rounded-md border object-contain bg-muted"
-                    />
-                  ) : (
-                    <span className="font-medium">{confirmProof}</span>
-                  )}
-                </div>
+                {(selectedActivity?.proof_requirement ?? 'mandatory') !== 'not_required' && (
+                  <div>
+                    <span className="text-muted-foreground block text-xs">
+                      Upload Proof{(selectedActivity?.proof_requirement ?? 'mandatory') === 'mandatory' ? ' (Required)' : ' (Optional)'}
+                    </span>
+                    {imagePreview ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={imagePreview}
+                        alt="Proof screenshot preview"
+                        className="mt-2 h-28 w-full rounded-md border object-contain bg-muted"
+                      />
+                    ) : (
+                      <span className="font-medium">{confirmProof}</span>
+                    )}
+                  </div>
+                )}
 
                 <div>
                   <span className="text-muted-foreground block text-xs">Estimated RR</span>

--- a/src/app/api/leagues/[id]/leaderboard/route.ts
+++ b/src/app/api/leagues/[id]/leaderboard/route.ts
@@ -277,38 +277,64 @@ export async function GET(
     // =========================================================================
     // Get all effort entries within date range
     // =========================================================================
-    let entriesQuery = supabase
-      .from('effortentry')
-      .select('id, league_member_id, date, type, workout_type, outcome, rr_value, status')
-      .in('league_member_id', memberIds);
+    // Supabase JS client defaults to 1000 rows. For leagues with many members
+    // this can silently truncate results, causing incorrect point totals.
+    // We paginate in chunks of 1000 to fetch ALL entries.
+    const PAGE_SIZE = 1000;
+    let entries: any[] = [];
+    let entriesError: any = null;
 
-    // Apply start bound:
-    // 1. If user provided a startDate in params, use that.
-    // 2. Otherwise (default view), use league.start_date to EXCLUDE trial submissions (dates < start_date).
-    if (startDate) {
-      entriesQuery = entriesQuery.gte('date', startDate);
-    } else {
-      // DEFAULT: Filter out entries before league start date
-      entriesQuery = entriesQuery.gte('date', league.start_date);
+    {
+      let page = 0;
+      let hasMore = true;
+      while (hasMore) {
+        let entriesQuery = supabase
+          .from('effortentry')
+          .select('id, league_member_id, date, type, workout_type, outcome, rr_value, status')
+          .in('league_member_id', memberIds);
+
+        if (startDate) {
+          entriesQuery = entriesQuery.gte('date', startDate);
+        } else {
+          entriesQuery = entriesQuery.gte('date', league.start_date);
+        }
+
+        entriesQuery = entriesQuery
+          .lte('date', effectiveEndDate)
+          .range(page * PAGE_SIZE, (page + 1) * PAGE_SIZE - 1);
+
+        const { data, error } = await entriesQuery;
+        if (error) {
+          entriesError = error;
+          break;
+        }
+        entries = entries.concat(data || []);
+        hasMore = (data?.length || 0) === PAGE_SIZE;
+        page++;
+      }
     }
-
-    // Always apply the delayed end bound.
-    entriesQuery = entriesQuery.lte('date', effectiveEndDate);
-
-    let { data: entries, error: entriesError } = await entriesQuery;
 
     // Fallback if 'outcome' or 'workout_type' columns don't exist yet
     if (entriesError && typeof entriesError?.message === 'string' && entriesError.message.toLowerCase().includes('column')) {
-      const fallbackQuery = supabase
-        .from('effortentry')
-        .select('id, league_member_id, date, type, rr_value, status')
-        .in('league_member_id', memberIds);
-      if (startDate) fallbackQuery.gte('date', startDate);
-      else fallbackQuery.gte('date', league.start_date);
-      fallbackQuery.lte('date', effectiveEndDate);
-      const fallback = await fallbackQuery;
-      entries = fallback.data;
-      entriesError = fallback.error;
+      entries = [];
+      entriesError = null;
+      let page = 0;
+      let hasMore = true;
+      while (hasMore) {
+        const fallbackQuery = supabase
+          .from('effortentry')
+          .select('id, league_member_id, date, type, rr_value, status')
+          .in('league_member_id', memberIds);
+        if (startDate) fallbackQuery.gte('date', startDate);
+        else fallbackQuery.gte('date', league.start_date);
+        fallbackQuery.lte('date', effectiveEndDate);
+        fallbackQuery.range(page * PAGE_SIZE, (page + 1) * PAGE_SIZE - 1);
+        const fallback = await fallbackQuery;
+        if (fallback.error) { entriesError = fallback.error; break; }
+        entries = entries.concat(fallback.data || []);
+        hasMore = (fallback.data?.length || 0) === PAGE_SIZE;
+        page++;
+      }
     }
 
     if (entriesError) {


### PR DESCRIPTION
## Summary
- **Leaderboard pagination**: Entries query was silently capping at 1000 rows (Supabase default). League has 1088+ entries, causing wrong points and empty real-time scoreboard. Now paginates in chunks to fetch all.
- **Points mismatch**: My Summary counted all approved entries without deduplication. Leaderboard deduplicates by date. Added date dedup to My Summary so both match.
- **League Info cards**: Restructured to 2 cols on mobile (3 rows), 3 cols on tablet/desktop (2 rows). Rest Days moved next to Days Total.
- **Confirm submission dialog**: Hidden unnecessary fields (Measurement when none, Notes when not required, Proof when not required).
- **Unique workout checkbox**: Only shown for individual challenges, hidden for team/sub_team/tournament.

## Test plan
- [ ] Leaderboard shows correct individual points (21 for top players, not 20)
- [ ] Real-time scoreboard shows non-zero scores for yesterday
- [ ] My Summary points match individual leaderboard rank
- [ ] League Info cards display 2x2 on mobile, 2x3 on desktop
- [ ] Confirm dialog hides measurement/proof/notes when not applicable
- [ ] Bingo (sub_team) challenge activation dialog does not show unique workout checkbox