### PR TITLE
Add multi-outcome UI, fix unique workout edit & custom activity toggle

### DIFF
--- a/src/app/(app)/leagues/[id]/activities/page.tsx
+++ b/src/app/(app)/leagues/[id]/activities/page.tsx
@@ -332,7 +332,7 @@ export default function LeagueActivitiesPage({
     }
   };
 
-  const handleActivityConfigChange = (config: { activity_id: string; proof_requirement: 'not_required' | 'optional' | 'mandatory'; notes_requirement: 'not_required' | 'optional' | 'mandatory'; points_per_session: number }) => {
+  const handleActivityConfigChange = (config: { activity_id: string; proof_requirement: 'not_required' | 'optional' | 'mandatory'; notes_requirement: 'not_required' | 'optional' | 'mandatory'; points_per_session: number; outcome_config?: { label: string; points: number }[] | null }) => {
     setPendingChanges((prev) => {
       const next = new Map(prev);
       const change = next.get(config.activity_id) || {};
@@ -341,6 +341,7 @@ export default function LeagueActivitiesPage({
         proof_requirement: config.proof_requirement,
         notes_requirement: config.notes_requirement,
         points_per_session: config.points_per_session,
+        outcome_config: config.outcome_config,
       });
       return next;
     });
@@ -375,11 +376,13 @@ export default function LeagueActivitiesPage({
         // But different activities can run in parallel.
         const activityPromise = (async (): Promise<{ ok: boolean }> => {
           const results: boolean[] = [];
+          const activityInfo = data?.allActivities?.find((a) => a.activity_id === activityId);
+          const isCustom = !!activityInfo?.is_custom;
 
           if (change.enabled !== undefined) {
             const success = change.enabled
-              ? await addActivities([activityId])
-              : await removeActivity(activityId);
+              ? await addActivities([activityId], isCustom)
+              : await removeActivity(activityId, isCustom);
             results.push(success);
             if (change.enabled === false) return { ok: results.every(Boolean) };
           }
@@ -825,6 +828,7 @@ export default function LeagueActivitiesPage({
                               proofRequirement={enabledActivityMap.get(activity.activity_id)?.proof_requirement ?? 'mandatory'}
                               notesRequirement={enabledActivityMap.get(activity.activity_id)?.notes_requirement ?? 'optional'}
                               pointsPerSession={enabledActivityMap.get(activity.activity_id)?.points_per_session ?? 1}
+                              outcomeConfig={enabledActivityMap.get(activity.activity_id)?.outcome_config ?? null}
                               onActivityConfigChange={handleActivityConfigChange}
                             />
                           </div>

--- a/src/app/(app)/leagues/[id]/configure-challenges/page.tsx
+++ b/src/app/(app)/leagues/[id]/configure-challenges/page.tsx
@@ -49,6 +49,7 @@ type Challenge = {
     end_date: string | null;
     doc_url: string | null;
     is_custom: boolean;
+    is_unique_workout?: boolean;
     template_id: string | null;
     pricing_id?: string | null;
     stats: { pending: number; approved: number; rejected: number } | null;
@@ -163,6 +164,7 @@ export default function ConfigureChallengesPage({ params }: { params: Promise<{ 
         docUrl: '',
         startDate: '',
         endDate: '',
+        isUniqueWorkout: false,
     });
 
     // Activate preset dialog state
@@ -386,6 +388,7 @@ export default function ConfigureChallengesPage({ params }: { params: Promise<{ 
             docUrl: challenge.doc_url || '',
             startDate: challenge.start_date ? challenge.start_date.split('T')[0] : '',
             endDate: challenge.end_date ? challenge.end_date.split('T')[0] : '',
+            isUniqueWorkout: !!challenge.is_unique_workout,
         });
         setSelectedFile(null);
         setEditOpen(true);
@@ -421,6 +424,7 @@ export default function ConfigureChallengesPage({ params }: { params: Promise<{ 
                 docUrl,
                 startDate: editForm.startDate || null,
                 endDate: editForm.endDate || null,
+                isUniqueWorkout: editForm.isUniqueWorkout,
             };
 
             const res = await fetch(`/api/leagues/${leagueId}/challenges/${editChallenge.id}`, {
@@ -1489,6 +1493,20 @@ export default function ConfigureChallengesPage({ params }: { params: Promise<{ 
                                 onChange={(e) => setSelectedFile(e.target.files?.[0] || null)}
                             />
                         </div>
+                        {editForm.challengeType === 'individual' && (
+                            <div className="flex items-center gap-2">
+                                <input
+                                    type="checkbox"
+                                    id="edit-unique-workout"
+                                    checked={editForm.isUniqueWorkout}
+                                    onChange={(e) => setEditForm((p) => ({ ...p, isUniqueWorkout: e.target.checked }))}
+                                    className="size-4 rounded border-gray-300"
+                                />
+                                <Label htmlFor="edit-unique-workout" className="text-sm font-normal cursor-pointer">
+                                    Unique Workout Challenge (players link a workout entry instead of uploading proof)
+                                </Label>
+                            </div>
+                        )}
                         <DialogFooter>
                             <Button type="button" variant="outline" onClick={() => setEditOpen(false)} disabled={editLoading}>Cancel</Button>
                             <Button type="submit" disabled={editLoading}>

--- a/src/app/api/leagues/[id]/challenges/[challengeId]/route.ts
+++ b/src/app/api/leagues/[id]/challenges/[challengeId]/route.ts
@@ -174,7 +174,8 @@ export async function PATCH(
       totalPoints,
       docUrl,
       startDate,
-      endDate
+      endDate,
+      isUniqueWorkout,
     } = body;
 
     const updates: Record<string, any> = {};
@@ -184,6 +185,7 @@ export async function PATCH(
     if (challengeType !== undefined) updates.challenge_type = challengeType;
     if (totalPoints !== undefined) updates.total_points = totalPoints;
     if (docUrl !== undefined) updates.doc_url = docUrl;
+    if (isUniqueWorkout !== undefined) updates.is_unique_workout = !!isUniqueWorkout;
 
     // Handle dates and status derivation if dates are provided
     if (startDate !== undefined) updates.start_date = startDate;

--- a/src/components/leagues/activity-minimum-dropdown.tsx
+++ b/src/components/leagues/activity-minimum-dropdown.tsx
@@ -61,6 +61,7 @@ interface ActivityMinimumProps {
   proofRequirement?: 'not_required' | 'optional' | 'mandatory';
   notesRequirement?: 'not_required' | 'optional' | 'mandatory';
   pointsPerSession?: number;
+  outcomeConfig?: { label: string; points: number }[] | null;
   onMinimumChange?: (config: {
     activity_id: string;
     min_value: number | null;
@@ -74,6 +75,7 @@ interface ActivityMinimumProps {
     proof_requirement: 'not_required' | 'optional' | 'mandatory';
     notes_requirement: 'not_required' | 'optional' | 'mandatory';
     points_per_session: number;
+    outcome_config?: { label: string; points: number }[] | null;
   }) => void;
 }
 
@@ -89,6 +91,7 @@ export function ActivityMinimumDropdown({
   proofRequirement = 'mandatory',
   notesRequirement = 'optional',
   pointsPerSession = 1,
+  outcomeConfig,
   onMinimumChange,
   onFrequencyChange,
   onFrequencyTypeChange,
@@ -110,6 +113,9 @@ export function ActivityMinimumDropdown({
   const [proofDraft, setProofDraft] = useState<'not_required' | 'optional' | 'mandatory'>(proofRequirement);
   const [notesDraft, setNotesDraft] = useState<'not_required' | 'optional' | 'mandatory'>(notesRequirement);
   const [pointsDraft, setPointsDraft] = useState<number>(pointsPerSession);
+  const [outcomeDraft, setOutcomeDraft] = useState<{ label: string; points: number }[]>(
+    outcomeConfig && outcomeConfig.length > 0 ? outcomeConfig : []
+  );
 
   // Sync state with initialConfig when it changes
   useEffect(() => {
@@ -131,6 +137,9 @@ export function ActivityMinimumDropdown({
   useEffect(() => { setProofDraft(proofRequirement); }, [proofRequirement]);
   useEffect(() => { setNotesDraft(notesRequirement); }, [notesRequirement]);
   useEffect(() => { setPointsDraft(pointsPerSession); }, [pointsPerSession]);
+  useEffect(() => {
+    setOutcomeDraft(outcomeConfig && outcomeConfig.length > 0 ? outcomeConfig : []);
+  }, [outcomeConfig]);
 
   useEffect(() => {
     if (frequencyDraft === '') return;
@@ -218,6 +227,7 @@ export function ActivityMinimumDropdown({
         proof_requirement: proofDraft,
         notes_requirement: notesDraft,
         points_per_session: pointsDraft,
+        outcome_config: outcomeDraft.length > 0 ? outcomeDraft.filter(o => o.label.trim()) : null,
       });
     }
     setIsExpanded(false);
@@ -452,6 +462,68 @@ export function ActivityMinimumDropdown({
                 onChange={(e) => setPointsDraft(e.target.value === '' ? 0 : Number(e.target.value))}
               />
             </div>
+          </div>
+
+          {/* Multi-Outcome */}
+          <div className="space-y-2 border-t pt-3">
+            <div className="flex items-center justify-between">
+              <h4 className="text-xs font-semibold">Outcome Options</h4>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => setOutcomeDraft((prev) => [...prev, { label: '', points: 1 }])}
+                className="h-6 px-2 text-xs gap-1"
+              >
+                <Plus className="size-3" />
+                Add
+              </Button>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Add outcomes like Win/Loss/Draw with different point values. Leave empty for single-outcome activities.
+            </p>
+            {outcomeDraft.length === 0 ? (
+              <p className="text-xs text-muted-foreground">
+                No outcomes configured. Default points per session applies.
+              </p>
+            ) : (
+              <div className="space-y-2">
+                {outcomeDraft.map((outcome, idx) => (
+                  <div key={idx} className="flex items-center gap-2">
+                    <Input
+                      placeholder="e.g. Win"
+                      value={outcome.label}
+                      onChange={(e) => {
+                        setOutcomeDraft((prev) =>
+                          prev.map((o, i) => (i === idx ? { ...o, label: e.target.value } : o))
+                        );
+                      }}
+                      className="h-7 text-xs flex-1"
+                    />
+                    <Input
+                      type="number"
+                      min={0}
+                      step={0.5}
+                      value={outcome.points}
+                      onChange={(e) => {
+                        setOutcomeDraft((prev) =>
+                          prev.map((o, i) => (i === idx ? { ...o, points: e.target.value === '' ? 0 : Number(e.target.value) } : o))
+                        );
+                      }}
+                      className="h-7 text-xs w-16"
+                    />
+                    <span className="text-[10px] text-muted-foreground">pts</span>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => setOutcomeDraft((prev) => prev.filter((_, i) => i !== idx))}
+                      className="h-6 w-6 p-0"
+                    >
+                      <Trash2 className="size-3 text-red-600" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
 
           {/* Save button */}


### PR DESCRIPTION
## Summary
- **Multi-outcome UI**: Hosts can now configure outcome options (e.g. Win/Loss/Draw) with different point values per activity from the Activities settings page
- **Unique workout checkbox in Edit dialog**: Challenge edit dialog now shows the unique workout checkbox (for individual challenges) and the PATCH API persists it
- **Custom activity toggle fix**: Enable/disable for custom activities now works correctly — passes `isCustom` flag so the API receives `custom_activity_id` instead of `activity_id`
- **DB update**: Set `is_unique_workout = true` for the RFL "Unique Workout Day" challenge (applied directly)

## Files changed
- `src/components/leagues/activity-minimum-dropdown.tsx` — Outcome Options section
- `src/app/(app)/leagues/[id]/activities/page.tsx` — outcome prop + isCustom fix
- `src/app/(app)/leagues/[id]/configure-challenges/page.tsx` — unique workout checkbox in edit dialog
- `src/app/api/leagues/[id]/challenges/[challengeId]/route.ts` — PATCH accepts isUniqueWorkout