### PR TITLE
Fix resubmit button disabled and custom fields not in activity config

### DIFF
--- a/src/app/(app)/leagues/[id]/submit/page.tsx
+++ b/src/app/(app)/leagues/[id]/submit/page.tsx
@@ -1649,7 +1649,7 @@ export default function SubmitActivityPage({
                   <Button
                     type="submit"
                     className="flex-1"
-                    disabled={loading || uploadingImage || !formData.activity_type || ((selectedActivity?.proof_requirement ?? 'mandatory') === 'mandatory' && !selectedFile)}
+                    disabled={loading || uploadingImage || !formData.activity_type || ((selectedActivity?.proof_requirement ?? 'mandatory') === 'mandatory' && !selectedFile && !resubmitId)}
                   >
                     {loading || uploadingImage ? (
                       <>

--- a/src/app/api/leagues/[id]/activities/route.ts
+++ b/src/app/api/leagues/[id]/activities/route.ts
@@ -413,6 +413,8 @@ export async function GET(
         notes_requirement,
         points_per_session,
         outcome_config,
+        max_images,
+        custom_field_label,
         activities(
           activity_id,
           activity_name,
@@ -442,7 +444,7 @@ export async function GET(
       const msg = activitiesError.message.toLowerCase();
 
       // Fallback: if proof_requirement/notes_requirement/points_per_session/outcome_config columns don't exist
-      if ((msg.includes('proof_requirement') || msg.includes('notes_requirement') || msg.includes('points_per_session') || msg.includes('outcome_config')) && msg.includes('column')) {
+      if ((msg.includes('proof_requirement') || msg.includes('notes_requirement') || msg.includes('points_per_session') || msg.includes('outcome_config') || msg.includes('max_images') || msg.includes('custom_field_label')) && msg.includes('column')) {
         const withoutNewCols = await supabase
           .from('leagueactivities')
           .select(`
@@ -601,6 +603,8 @@ export async function GET(
           notes_requirement: (la as any).notes_requirement ?? 'optional',
           points_per_session: (la as any).points_per_session ?? 1,
           outcome_config: (la as any).outcome_config ?? null,
+          max_images: (la as any).max_images ?? 1,
+          custom_field_label: (la as any).custom_field_label ?? null,
         };
       });
 


### PR DESCRIPTION
## Summary
- **Resubmit button fix**: Submit button was disabled during resubmission because proof requirement check didn't have a `resubmitId` exception (matching the existing server-side logic)
- **Custom fields fix**: Activities API wasn't fetching `max_images`/`custom_field_label` from DB, and global activity response was missing these fields

## Test plan
- [ ] Reject a player's activity → as that player, click Resubmit → submit button should be clickable without re-uploading proof
- [ ] As host, go to Activities → Configure any activity → Max Images and Custom Field Label should be visible under Submission Settings