### PR TITLE
Fix custom activity min duration and points_per_session

### DIFF
--- a/src/app/(app)/leagues/[id]/page.tsx
+++ b/src/app/(app)/leagues/[id]/page.tsx
@@ -671,6 +671,14 @@ export default function LeagueDashboardPage({
               }
             }
 
+            // Extract individual points from leaderboard (respects points_per_session config)
+            const individuals: Array<{ user_id: string; points?: number }> =
+              leaderboardData?.data?.individuals || [];
+            const myIndividual = individuals.find((i) => String(i.user_id) === String(user?.id));
+            if (myIndividual && typeof myIndividual.points === 'number') {
+              points = myIndividual.points;
+            }
+
             // Individual stats: challenge points are no longer added to individual totals.
             // Individual players only see activity points - all challenge points go to team.
             // totalPoints for individual = activity points only

--- a/src/app/(app)/leagues/[id]/submit/page.tsx
+++ b/src/app/(app)/leagues/[id]/submit/page.tsx
@@ -2117,7 +2117,7 @@ export default function SubmitActivityPage({
           </DialogHeader>
 
           {(submittedData?.rr_value || submittedData?.isRestDay) && (
-            <div className="flex justify-center py-2">
+            <div className="flex justify-center gap-3 py-2">
               <div className={cn(
                 "inline-flex items-center gap-2 px-5 py-2.5 rounded-full border",
                 submittedData?.isExemption
@@ -2131,7 +2131,15 @@ export default function SubmitActivityPage({
                   +{submittedData?.rr_value?.toFixed(1) || '1.0'}
                 </span>
                 <span className="text-sm text-muted-foreground">
-                  RR points {submittedData?.isExemption && '(if approved)'}
+                  RR {submittedData?.isExemption && '(if approved)'}
+                </span>
+              </div>
+              <div className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full border bg-gradient-to-r from-purple-500/10 to-indigo-500/10 border-purple-500/20">
+                <span className="text-2xl font-bold text-purple-600">
+                  +{submittedData?.points_per_session ?? 1}
+                </span>
+                <span className="text-sm text-muted-foreground">
+                  point{(submittedData?.points_per_session ?? 1) !== 1 ? 's' : ''}
                 </span>
               </div>
             </div>

--- a/src/app/api/entries/preview-rr/route.ts
+++ b/src/app/api/entries/preview-rr/route.ts
@@ -91,6 +91,36 @@ export async function POST(req: NextRequest) {
       }
     }
 
+    // Fetch league-configured min_value for this activity to override baseDuration
+    if (workout_type && league_id) {
+      const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(workout_type);
+      let configRow: any = null;
+
+      if (isUuid) {
+        const { data } = await supabase
+          .from('leagueactivities')
+          .select('min_value')
+          .eq('league_id', league_id)
+          .eq('custom_activity_id', workout_type)
+          .maybeSingle();
+        if (data) configRow = data;
+      }
+
+      if (!configRow) {
+        const { data } = await supabase
+          .from('leagueactivities')
+          .select('min_value, activities!inner(activity_name)')
+          .eq('league_id', league_id)
+          .eq('activities.activity_name', workout_type)
+          .maybeSingle();
+        if (data) configRow = data;
+      }
+
+      if (configRow && typeof configRow.min_value === 'number' && configRow.min_value > 0) {
+        baseDuration = configRow.min_value;
+      }
+    }
+
     let rr_value = 0;
 
     if (type === 'rest') {

--- a/src/app/api/entries/upsert/route.ts
+++ b/src/app/api/entries/upsert/route.ts
@@ -392,7 +392,7 @@ export async function POST(req: NextRequest) {
         // Custom activity — lookup by custom_activity_id
         const { data, error } = await supabase
           .from('leagueactivities')
-          .select('proof_requirement, notes_requirement, points_per_session, outcome_config')
+          .select('proof_requirement, notes_requirement, points_per_session, outcome_config, min_value')
           .eq('league_id', league_id)
           .eq('custom_activity_id', workout_type)
           .maybeSingle();
@@ -404,7 +404,7 @@ export async function POST(req: NextRequest) {
         // Global activity — lookup by activity name via join
         const { data, error } = await supabase
           .from('leagueactivities')
-          .select('proof_requirement, notes_requirement, points_per_session, outcome_config, activities!inner(activity_name)')
+          .select('proof_requirement, notes_requirement, points_per_session, outcome_config, min_value, activities!inner(activity_name)')
           .eq('league_id', league_id)
           .eq('activities.activity_name', workout_type)
           .maybeSingle();
@@ -416,6 +416,11 @@ export async function POST(req: NextRequest) {
         activityNotesRequirement = activityConfigRow.notes_requirement ?? 'optional';
         activityPointsPerSession = activityConfigRow.points_per_session ?? 1;
         activityOutcomeConfig = activityConfigRow.outcome_config ?? null;
+
+        // Use league-configured minimum duration instead of hardcoded default
+        if (typeof activityConfigRow.min_value === 'number' && activityConfigRow.min_value > 0) {
+          baseDuration = activityConfigRow.min_value;
+        }
       }
     }
 
@@ -607,7 +612,7 @@ export async function POST(req: NextRequest) {
 
         return NextResponse.json({
           success: true,
-          data: updated,
+          data: { ...updated, points_per_session: activityPointsPerSession },
           updated: true,
           replacedRejected: canReplaceRejected,
           overwritten: !!overwrite
@@ -643,7 +648,7 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({
       success: true,
-      data: created,
+      data: { ...created, points_per_session: activityPointsPerSession },
       created: true
     });
   } catch (error) {

--- a/src/lib/services/league-report.ts
+++ b/src/lib/services/league-report.ts
@@ -412,19 +412,35 @@ async function getRankings(
     const memberIds = allMembers.map(m => m.league_member_id);
 
     // Get all approved entries for scoring
-    // LOGIC MATCH: Same as /api/leagues/[id]/leaderboard
-    // 1 point per approved entry
+    // LOGIC MATCH: Same as /api/leagues/[id]/leaderboard — use points_per_session from leagueactivities
     const { data: allEntries } = await supabase
         .from('effortentry')
-        .select('league_member_id, rr_value')
+        .select('league_member_id, rr_value, workout_type')
         .eq('status', 'approved')
         .in('league_member_id', memberIds);
 
-    // Calculate points per member (1 point per entry)
+    // Fetch activity points configuration for this league
+    const activityPointsMap = new Map<string, number>();
+    const { data: laRows } = await supabase
+        .from('leagueactivities')
+        .select('activity_id, custom_activity_id, points_per_session, activities(activity_name)')
+        .eq('league_id', leagueId);
+    for (const row of (laRows || [])) {
+        const pts = (row as any).points_per_session ?? 1;
+        if ((row as any).activities?.activity_name) {
+            activityPointsMap.set((row as any).activities.activity_name, pts);
+        }
+        if (row.custom_activity_id) {
+            activityPointsMap.set(row.custom_activity_id, pts);
+        }
+    }
+
+    // Calculate points per member using configured points_per_session
     const memberPoints = new Map<string, number>();
     for (const entry of (allEntries || [])) {
         const current = memberPoints.get(entry.league_member_id) || 0;
-        memberPoints.set(entry.league_member_id, current + 1); // 1 point per approved entry
+        const pts = (entry as any).workout_type ? (activityPointsMap.get((entry as any).workout_type) ?? 1) : 1;
+        memberPoints.set(entry.league_member_id, current + pts);
     }
 
     // Map user_id to points


### PR DESCRIPTION
## Summary
- **Bug 1:** Custom activity minimum duration (e.g., 10 min) was ignored by backend — upsert and preview-rr APIs used hardcoded 45 min, causing valid submissions to be rejected
- **Bug 2:** Custom points_per_session (e.g., 3 pts) was ignored — league page, submit confirmation, and league report all hardcoded 1 point per entry

## Changes
- `upsert/route.ts` & `preview-rr/route.ts`: Fetch `min_value` from `leagueactivities` instead of hardcoded `baseDuration = 45`
- `leagues/[id]/page.tsx`: Use leaderboard API individual points (which respects `points_per_session`) instead of `dedupedApproved.length`
- `submit/page.tsx`: Show both RR and actual points earned in confirmation dialog
- `league-report.ts`: Query `points_per_session` from `leagueactivities` instead of hardcoding 1

## Test plan
- [ ] Submit activity with custom min duration (e.g., 10 min) — should accept duration >= 10 min
- [ ] Submit activity with custom points_per_session (e.g., 3) — confirmation should show "+3 points"
- [ ] Verify league page individual points reflect correct points_per_session
- [ ] Verify leaderboard points match