### PR TITLE
Fix submissions count capped at 1000 and revert points badge

### DIFF
--- a/src/app/(app)/leagues/[id]/submit/page.tsx
+++ b/src/app/(app)/leagues/[id]/submit/page.tsx
@@ -2117,7 +2117,7 @@ export default function SubmitActivityPage({
           </DialogHeader>
 
           {(submittedData?.rr_value || submittedData?.isRestDay) && (
-            <div className="flex justify-center gap-3 py-2">
+            <div className="flex justify-center py-2">
               <div className={cn(
                 "inline-flex items-center gap-2 px-5 py-2.5 rounded-full border",
                 submittedData?.isExemption
@@ -2131,15 +2131,7 @@ export default function SubmitActivityPage({
                   +{submittedData?.rr_value?.toFixed(1) || '1.0'}
                 </span>
                 <span className="text-sm text-muted-foreground">
-                  RR {submittedData?.isExemption && '(if approved)'}
-                </span>
-              </div>
-              <div className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full border bg-gradient-to-r from-purple-500/10 to-indigo-500/10 border-purple-500/20">
-                <span className="text-2xl font-bold text-purple-600">
-                  +{submittedData?.points_per_session ?? 1}
-                </span>
-                <span className="text-sm text-muted-foreground">
-                  point{(submittedData?.points_per_session ?? 1) !== 1 ? 's' : ''}
+                  RR points {submittedData?.isExemption && '(if approved)'}
                 </span>
               </div>
             </div>

--- a/src/app/api/leagues/[id]/submissions/route.ts
+++ b/src/app/api/leagues/[id]/submissions/route.ts
@@ -136,36 +136,55 @@ export async function GET(
     const memberIds = members.map((m) => m.league_member_id);
 
     // Build query for all submissions
-    let query = supabase
-      .from('effortentry')
-      .select(`
-        id,
-        league_member_id,
-        date,
-        type,
-        workout_type,
-        duration,
-        distance,
-        steps,
-        holes,
-        rr_value,
-        status,
-        proof_url,
-        notes,
-        created_date,
-        modified_date,
-        reupload_of,
-        rejection_reason
-      `)
-      .in('league_member_id', memberIds)
-      .order('date', { ascending: false });
+    // Supabase JS client defaults to 1000 rows. Paginate in chunks to fetch ALL entries.
+    const PAGE_SIZE = 1000;
+    let submissions: any[] = [];
+    let submissionsError: any = null;
 
-    // Apply optional status filter
-    if (status) {
-      query = query.eq('status', status);
+    {
+      let page = 0;
+      let hasMore = true;
+      while (hasMore) {
+        let query = supabase
+          .from('effortentry')
+          .select(`
+            id,
+            league_member_id,
+            date,
+            type,
+            workout_type,
+            duration,
+            distance,
+            steps,
+            holes,
+            rr_value,
+            status,
+            proof_url,
+            notes,
+            created_date,
+            modified_date,
+            reupload_of,
+            rejection_reason
+          `)
+          .in('league_member_id', memberIds)
+          .order('date', { ascending: false });
+
+        if (status) {
+          query = query.eq('status', status);
+        }
+
+        query = query.range(page * PAGE_SIZE, (page + 1) * PAGE_SIZE - 1);
+
+        const { data, error } = await query;
+        if (error) {
+          submissionsError = error;
+          break;
+        }
+        submissions = submissions.concat(data || []);
+        hasMore = (data?.length || 0) === PAGE_SIZE;
+        page++;
+      }
     }
-
-    const { data: submissions, error: submissionsError } = await query;
 
     if (submissionsError) {
       console.error('Error fetching submissions:', submissionsError);


### PR DESCRIPTION
## Summary
- **Submissions count stuck at 1000:** Supabase JS client silently truncates at 1000 rows. Added pagination (same pattern as leaderboard route) to fetch all entries.
- **Reverted +1 point badge:** Removed the unrequested points badge from the submit confirmation dialog, restoring original RR-only display.

## Test plan
- [ ] Verify host "All Submissions" page shows correct total beyond 1000
- [ ] Verify submit confirmation shows only RR value (no points badge)