### PR TITLE
Fix challenge system bugs

### DIFF
--- a/src/app/(app)/leagues/[id]/configure-challenges/page.tsx
+++ b/src/app/(app)/leagues/[id]/configure-challenges/page.tsx
@@ -466,89 +466,23 @@ export default function ConfigureChallengesPage({ params }: { params: Promise<{ 
             toast.error('Start date and end date are required');
             return;
         }
-        if (!pricing?.per_day_rate) {
-            toast.error('Pricing not available');
-            return;
-        }
-        const base = (finishDays || 0) * (pricing.per_day_rate || 0);
-        const taxPercent = pricing.tax != null ? pricing.tax : 0;
-        const amount = base + (taxPercent / 100) * base;
-        if (!amount || amount <= 0) {
-            toast.error('Amount is invalid');
-            return;
-        }
         setFinishing(true);
         try {
-            const orderRes = await fetch('/api/payments/challenge-order', {
-                method: 'POST',
+            const payload = { startDate: finishStart, endDate: finishEnd };
+            const patchRes = await fetch(`/api/leagues/${leagueId}/challenges/${finishChallenge.id}`, {
+                method: 'PATCH',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    leagueId,
-                    challengeId: finishChallenge.id,
-                    startDate: finishStart,
-                    endDate: finishEnd,
-                }),
+                body: JSON.stringify(payload),
             });
-
-            const orderJson = await orderRes.json();
-            if (!orderRes.ok || orderJson.error) {
-                throw new Error(orderJson.error || 'Failed to start payment');
+            const patchJson = await patchRes.json();
+            if (!patchRes.ok || !patchJson.success) {
+                throw new Error(patchJson.error || 'Failed to activate challenge');
             }
 
-            const Razorpay = await loadRazorpay();
-            if (!Razorpay) throw new Error('Razorpay unavailable');
-
-            const options = {
-                key: orderJson.keyId,
-                amount: orderJson.amount,
-                currency: orderJson.currency || 'INR',
-                name: 'Challenge Activation',
-                description: finishChallenge.name,
-                order_id: orderJson.orderId,
-                notes: { leagueId, challengeId: finishChallenge.id },
-                handler: async (response: any) => {
-                    try {
-                        const verifyRes = await fetch('/api/payments/verify', {
-                            method: 'POST',
-                            headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify({
-                                orderId: response.razorpay_order_id,
-                                paymentId: response.razorpay_payment_id,
-                                signature: response.razorpay_signature,
-                            }),
-                        });
-                        const verifyJson = await verifyRes.json();
-                        if (!verifyRes.ok || verifyJson.error) {
-                            throw new Error(verifyJson.error || 'Payment verification failed');
-                        }
-
-                        const payload = { startDate: finishStart, endDate: finishEnd };
-                        const patchRes = await fetch(`/api/leagues/${leagueId}/challenges/${finishChallenge.id}`, {
-                            method: 'PATCH',
-                            headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify(payload),
-                        });
-                        const patchJson = await patchRes.json();
-                        if (!patchRes.ok || !patchJson.success) {
-                            throw new Error(patchJson.error || 'Failed to update challenge after payment');
-                        }
-
-                        toast.success('Payment successful. Challenge activated.');
-                        setFinishOpen(false);
-                        setFinishChallenge(null);
-                        fetchChallenges();
-                    } catch (err: any) {
-                        toast.error(err?.message || 'Payment succeeded but activation failed');
-                    }
-                },
-                theme: { color: '#0F172A' },
-            } as any;
-
-            const rzp = new Razorpay(options);
-            rzp.on('payment.failed', (resp: any) => {
-                toast.error(resp?.error?.description || 'Payment failed');
-            });
-            rzp.open();
+            toast.success('Challenge activated.');
+            setFinishOpen(false);
+            setFinishChallenge(null);
+            fetchChallenges();
         } catch (err) {
             toast.error(err instanceof Error ? err.message : 'Failed to finish setup');
         } finally {
@@ -904,21 +838,41 @@ export default function ConfigureChallengesPage({ params }: { params: Promise<{ 
                                             size="sm"
                                             variant="outline"
                                             onClick={() => handleOpenReview(challenge)}
-                                            disabled={challenge.status !== 'submission_closed' && challenge.status !== 'published'}
-                                            title={['submission_closed', 'published'].includes(challenge.status) ? '' : 'Reviews open after submissions close'}
+                                            disabled={
+                                                challenge.challenge_type === 'team'
+                                                    ? challenge.status === 'draft'
+                                                    : challenge.status !== 'submission_closed' && challenge.status !== 'published'
+                                            }
+                                            title={
+                                                challenge.challenge_type === 'team'
+                                                    ? 'Assign team scores'
+                                                    : ['submission_closed', 'published'].includes(challenge.status) ? '' : 'Reviews open after submissions close'
+                                            }
                                         >
-                                            Review
+                                            {challenge.challenge_type === 'team' ? 'Assign Scores' : 'Review'}
                                         </Button>
                                     )}
 
-                                    {challenge.status === 'submission_closed' && challenge.challenge_type !== 'tournament' && (
-                                        <Button
-                                            size="sm"
-                                            onClick={() => handlePublish(challenge)}
-                                            disabled={publishingId === challenge.id || (challenge.stats?.pending ?? 0) > 0}
-                                        >
-                                            {publishingId === challenge.id ? 'Publishing...' : 'Publish Scores'}
-                                        </Button>
+                                    {challenge.challenge_type !== 'tournament' && (
+                                        challenge.challenge_type === 'team'
+                                            ? challenge.status !== 'draft' && challenge.status !== 'published' && (
+                                                <Button
+                                                    size="sm"
+                                                    onClick={() => handlePublish(challenge)}
+                                                    disabled={publishingId === challenge.id}
+                                                >
+                                                    {publishingId === challenge.id ? 'Publishing...' : 'Publish Scores'}
+                                                </Button>
+                                            )
+                                            : challenge.status === 'submission_closed' && (
+                                                <Button
+                                                    size="sm"
+                                                    onClick={() => handlePublish(challenge)}
+                                                    disabled={publishingId === challenge.id || (challenge.stats?.pending ?? 0) > 0}
+                                                >
+                                                    {publishingId === challenge.id ? 'Publishing...' : 'Publish Scores'}
+                                                </Button>
+                                            )
                                     )}
 
                                     {challenge.status === 'published' && challenge.challenge_type === 'tournament' && (
@@ -1371,17 +1325,10 @@ export default function ConfigureChallengesPage({ params }: { params: Promise<{ 
                             <Input type="date" value={finishEnd} onChange={(e) => setFinishEnd(e.target.value)} />
                         </div>
                     </div>
-                    {finishDays > 0 && pricing?.per_day_rate && (
-                        <div className="rounded-lg border p-3 text-sm space-y-1">
-                            <p>Duration: {finishDays} days</p>
-                            <p>Rate: ₹{pricing.per_day_rate}/day</p>
-                            <p className="font-semibold">Total: ₹{finishAmount.toFixed(2)}</p>
-                        </div>
-                    )}
                     <DialogFooter>
                         <Button variant="outline" onClick={() => setFinishOpen(false)}>Cancel</Button>
                         <Button onClick={handleFinishSubmit} disabled={finishing}>
-                            {finishing ? 'Processing...' : 'Pay & Activate'}
+                            {finishing ? 'Activating...' : 'Activate Challenge'}
                         </Button>
                     </DialogFooter>
                 </DialogContent>

--- a/src/app/api/leagues/[id]/challenges/[challengeId]/publish/route.ts
+++ b/src/app/api/leagues/[id]/challenges/[challengeId]/publish/route.ts
@@ -128,23 +128,83 @@ export async function POST(
       return buildError('Challenge scores are already published', 400);
     }
 
-    if (effectiveStatus !== 'submission_closed') {
+    // Team challenges can be published anytime (host enters scores directly)
+    // Other types require submissions to be closed first
+    if (challenge.challenge_type !== 'team' && effectiveStatus !== 'submission_closed') {
       return buildError('Publishing is allowed only after submissions have closed', 400);
     }
 
-    const { count: pendingCount, error: pendingError } = await supabase
-      .from('challenge_submissions')
-      .select('id', { count: 'exact', head: true })
-      .eq('league_challenge_id', challengeId)
-      .eq('status', 'pending');
+    if (challenge.challenge_type !== 'team') {
+      const { count: pendingCount, error: pendingError } = await supabase
+        .from('challenge_submissions')
+        .select('id', { count: 'exact', head: true })
+        .eq('league_challenge_id', challengeId)
+        .eq('status', 'pending');
 
-    if (pendingError) {
-      console.error('Error counting pending submissions:', pendingError);
-      return buildError('Failed to verify pending submissions', 500);
+      if (pendingError) {
+        console.error('Error counting pending submissions:', pendingError);
+        return buildError('Failed to verify pending submissions', 500);
+      }
+
+      if ((pendingCount || 0) > 0) {
+        return buildError('Review all pending submissions before publishing', 400);
+      }
     }
 
-    if ((pendingCount || 0) > 0) {
-      return buildError('Review all pending submissions before publishing', 400);
+    // Sub-team all-or-nothing: zero out points for incomplete sub-teams
+    if (challenge.challenge_type === 'sub_team') {
+      const { data: subteams } = await supabase
+        .from('challenge_subteams')
+        .select('subteam_id, name')
+        .eq('league_challenge_id', challengeId);
+
+      if (subteams && subteams.length > 0) {
+        for (const subteam of subteams) {
+          // Get all members of this sub-team
+          const { data: members } = await supabase
+            .from('challenge_subteam_members')
+            .select('league_member_id')
+            .eq('subteam_id', subteam.subteam_id);
+
+          if (!members || members.length === 0) continue;
+
+          const memberIds = members.map((m: any) => m.league_member_id);
+
+          // Check which members have approved submissions
+          const { data: approvedSubs } = await supabase
+            .from('challenge_submissions')
+            .select('league_member_id')
+            .eq('league_challenge_id', challengeId)
+            .eq('status', 'approved')
+            .in('league_member_id', memberIds);
+
+          const approvedMemberIds = new Set(
+            (approvedSubs || []).map((s: any) => String(s.league_member_id))
+          );
+
+          const allSubmitted = memberIds.every((id: string) =>
+            approvedMemberIds.has(String(id))
+          );
+
+          if (!allSubmitted) {
+            // Zero out awarded_points for all members of this incomplete sub-team
+            console.log(
+              `Sub-team "${subteam.name}" (${subteam.subteam_id}) incomplete — zeroing points for ${memberIds.length} members`
+            );
+
+            const { error: zeroError } = await supabase
+              .from('challenge_submissions')
+              .update({ awarded_points: 0 })
+              .eq('league_challenge_id', challengeId)
+              .eq('status', 'approved')
+              .in('league_member_id', memberIds);
+
+            if (zeroError) {
+              console.error('Error zeroing sub-team points:', zeroError);
+            }
+          }
+        }
+      }
     }
 
     const { data: updated, error: updateError } = await supabase

--- a/src/app/api/leagues/[id]/challenges/[challengeId]/team-score/route.ts
+++ b/src/app/api/leagues/[id]/challenges/[challengeId]/team-score/route.ts
@@ -1,0 +1,127 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth/config';
+import { getSupabaseServiceRole } from '@/lib/supabase/client';
+
+export async function POST(
+    req: NextRequest,
+    { params }: { params: Promise<{ id: string; challengeId: string }> }
+) {
+    try {
+        const { id: leagueId, challengeId } = await params;
+        const session = (await getServerSession(authOptions as any)) as import('next-auth').Session | null;
+
+        if (!session?.user?.id) {
+            return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+        }
+
+        const supabase = getSupabaseServiceRole();
+        const userId = session.user.id;
+
+        // Verify host/governor role
+        const { data: memberRoles, error: roleError } = await supabase
+            .from('assignedrolesforleague')
+            .select('role_id, roles(role_name)')
+            .eq('user_id', userId)
+            .eq('league_id', leagueId);
+
+        const hasAdminRole = memberRoles?.some((r: any) => {
+            const roleName = r.roles?.role_name;
+            return roleName === 'host' || roleName === 'governor';
+        });
+
+        if (roleError || !hasAdminRole) {
+            return NextResponse.json({ success: false, error: 'Only hosts/governors can assign team scores' }, { status: 403 });
+        }
+
+        const body = await req.json();
+        const { teamId, score } = body;
+
+        if (!teamId || typeof score !== 'number' || score < 0) {
+            return NextResponse.json({ success: false, error: 'teamId and valid score are required' }, { status: 400 });
+        }
+
+        // Get the league challenge
+        const { data: challenge, error: challengeError } = await supabase
+            .from('leagueschallenges')
+            .select('*')
+            .eq('id', challengeId)
+            .eq('league_id', leagueId)
+            .single();
+
+        if (challengeError || !challenge) {
+            return NextResponse.json({ success: false, error: 'Challenge not found' }, { status: 404 });
+        }
+
+        let parentChallengeId = challenge.challenge_id;
+
+        // If no parent challenge exists, create a placeholder (same as finalize route)
+        if (!parentChallengeId) {
+            const { data: newParent, error: createError } = await supabase
+                .from('specialchallenges')
+                .insert({
+                    name: challenge.name || 'Team Challenge Placeholder',
+                    description: 'Auto-generated parent for team score tracking',
+                    challenge_type: 'team',
+                    is_custom: true,
+                    created_by: userId,
+                })
+                .select('challenge_id')
+                .single();
+
+            if (createError || !newParent) {
+                return NextResponse.json({ success: false, error: 'Failed to initialize scoring system' }, { status: 500 });
+            }
+
+            parentChallengeId = newParent.challenge_id;
+
+            await supabase
+                .from('leagueschallenges')
+                .update({ challenge_id: parentChallengeId })
+                .eq('id', challengeId);
+        }
+
+        // Upsert the team score
+        const { data: existing } = await supabase
+            .from('specialchallengeteamscore')
+            .select('id')
+            .eq('challenge_id', parentChallengeId)
+            .eq('team_id', teamId)
+            .eq('league_id', leagueId)
+            .maybeSingle();
+
+        if (existing) {
+            const { error: updateError } = await supabase
+                .from('specialchallengeteamscore')
+                .update({
+                    score,
+                    modified_by: userId,
+                    modified_date: new Date().toISOString(),
+                })
+                .eq('id', existing.id);
+
+            if (updateError) {
+                return NextResponse.json({ success: false, error: 'Failed to update score' }, { status: 500 });
+            }
+        } else {
+            const { error: insertError } = await supabase
+                .from('specialchallengeteamscore')
+                .insert({
+                    challenge_id: parentChallengeId,
+                    team_id: teamId,
+                    league_id: leagueId,
+                    score,
+                    created_by: userId,
+                });
+
+            if (insertError) {
+                return NextResponse.json({ success: false, error: 'Failed to save score' }, { status: 500 });
+            }
+        }
+
+        return NextResponse.json({ success: true, message: 'Team score assigned' });
+    } catch (err) {
+        console.error('Error in team-score POST:', err);
+        return NextResponse.json({ success: false, error: 'Internal server error' }, { status: 500 });
+    }
+}

--- a/src/app/api/leagues/[id]/challenges/route.ts
+++ b/src/app/api/leagues/[id]/challenges/route.ts
@@ -353,15 +353,6 @@ export async function POST(
 
     const normalizedStatus = normalizeStatus(status);
 
-    // Fetch the default pricing_id from the singleton challengepricing table
-    const { data: defaultPricing } = await supabase
-      .from('challengepricing')
-      .select('pricing_id')
-      .limit(1)
-      .maybeSingle();
-
-    const resolvedPricingId = incomingPricingId || defaultPricing?.pricing_id || null;
-
     const insertPayload: Record<string, any> = {
       league_id: leagueId,
       name,
@@ -374,9 +365,9 @@ export async function POST(
       challenge_id: templateId ?? null,
       is_custom: isCustom,
       is_unique_workout: isUniqueWorkout,
-      payment_id: null, // Would be set after payment succeeds
+      payment_id: null,
       status: normalizedStatus,
-      pricing_id: resolvedPricingId,
+      pricing_id: null, // Costing removed per client request
     };
 
     const { data, error } = await supabase


### PR DESCRIPTION
## Summary
- Removed Razorpay payment gate from challenge creation — "Activate Challenge" now works directly
- Created missing `team-score` API route so hosts can assign team scores
- Team challenges can be reviewed/published at any active status (not just after submissions close)
- Sub-team all-or-nothing scoring: if any member hasn't submitted, entire sub-team gets 0 on publish

## Test plan
- [ ] Create a new challenge → verify no payment prompt, "Activate Challenge" works
- [ ] Open a team challenge → verify "Assign Scores" button is enabled, scores can be saved
- [ ] Publish a team challenge while still active → should succeed
- [ ] Publish a sub_team challenge with incomplete sub-team → verify that sub-team gets 0 points