### PR TITLE
Fix bugs from PR #105 review

### DIFF
--- a/src/app/(app)/leagues/[id]/configure-challenges/page.tsx
+++ b/src/app/(app)/leagues/[id]/configure-challenges/page.tsx
@@ -135,7 +135,6 @@ export default function ConfigureChallengesPage({ params }: { params: Promise<{ 
     const [error, setError] = React.useState<string | null>(null);
     const [challenges, setChallenges] = React.useState<Challenge[]>([]);
     const [presets, setPresets] = React.useState<any[]>([]);
-    const [pricing, setPricing] = React.useState<{ pricing_id?: string | null; per_day_rate?: number | null; tax?: number | null; admin_markup?: number | null } | null>(null);
     const [selectedPresetId, setSelectedPresetId] = React.useState<string>('');
 
     // Create challenge dialog state
@@ -216,23 +215,6 @@ export default function ConfigureChallengesPage({ params }: { params: Promise<{ 
     const [tournamentFinalizeOpen, setTournamentFinalizeOpen] = React.useState(false);
     const [manageChallenge, setManageChallenge] = React.useState<Challenge | null>(null);
 
-    const finishDays = React.useMemo(() => {
-        if (!finishStart || !finishEnd) return 0;
-        const start = new Date(finishStart);
-        const end = new Date(finishEnd);
-        if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return 0;
-        const diff = Math.floor((end.getTime() - start.getTime()) / (24 * 60 * 60 * 1000));
-        return diff >= 0 ? diff + 1 : 0;
-    }, [finishStart, finishEnd]);
-
-    const finishAmount = React.useMemo(() => {
-        if (!pricing?.per_day_rate || !finishDays) return 0;
-        const base = finishDays * (pricing.per_day_rate || 0);
-        const taxPercent = pricing.tax != null ? pricing.tax : 0;
-        const taxMultiplier = taxPercent / 100;
-        return base + taxMultiplier * base;
-    }, [pricing, finishDays]);
-
     const fetchChallenges = React.useCallback(async () => {
         setLoading(true);
         setError(null);
@@ -244,7 +226,6 @@ export default function ConfigureChallengesPage({ params }: { params: Promise<{ 
             }
             setChallenges(json.data?.active || []);
             setPresets(json.data?.availablePresets || []);
-            setPricing(json.data?.defaultPricing || null);
         } catch (err) {
             setError(err instanceof Error ? err.message : 'Failed to load challenges');
         } finally {
@@ -259,20 +240,6 @@ export default function ConfigureChallengesPage({ params }: { params: Promise<{ 
     React.useEffect(() => {
         fetchTeams();
     }, [leagueId]);
-
-    // Utility to load Razorpay script lazily
-    const loadRazorpay = React.useCallback(async () => {
-        if (typeof window === 'undefined') return null;
-        if ((window as any).Razorpay) return (window as any).Razorpay;
-        await new Promise<void>((resolve, reject) => {
-            const script = document.createElement('script');
-            script.src = 'https://checkout.razorpay.com/v1/checkout.js';
-            script.onload = () => resolve();
-            script.onerror = () => reject(new Error('Failed to load Razorpay'));
-            document.body.appendChild(script);
-        });
-        return (window as any).Razorpay;
-    }, []);
 
     const handleActivatePreset = () => {
         const preset = presets.find((p) => p.id === selectedPresetId);

--- a/src/app/api/leagues/[id]/challenges/[challengeId]/publish/route.ts
+++ b/src/app/api/leagues/[id]/challenges/[challengeId]/publish/route.ts
@@ -201,6 +201,7 @@ export async function POST(
 
             if (zeroError) {
               console.error('Error zeroing sub-team points:', zeroError);
+              return buildError('Failed to apply sub-team scoring rules', 500);
             }
           }
         }
@@ -220,12 +221,18 @@ export async function POST(
       return buildError('Failed to publish scores', 500);
     }
 
-    await syncSpecialChallengeScores({
-      leagueChallengeId: challengeId,
-      challengeId: updated.challenge_id,
-      leagueId,
-      challengeType: updated.challenge_type,
-    });
+    try {
+      await syncSpecialChallengeScores({
+        leagueChallengeId: challengeId,
+        challengeId: updated.challenge_id,
+        leagueId,
+        challengeType: updated.challenge_type,
+      });
+    } catch (syncErr) {
+      // Publish succeeded but score sync failed — log but don't return 500
+      // so the client knows publish worked and can retry score sync separately
+      console.error('Score sync failed after publish:', syncErr);
+    }
 
     return NextResponse.json({ success: true, status: 'published' });
   } catch (err: any) {

--- a/src/app/api/leagues/[id]/challenges/[challengeId]/team-score/route.ts
+++ b/src/app/api/leagues/[id]/challenges/[challengeId]/team-score/route.ts
@@ -75,10 +75,14 @@ export async function POST(
 
             parentChallengeId = newParent.challenge_id;
 
-            await supabase
+            const { error: linkError } = await supabase
                 .from('leagueschallenges')
                 .update({ challenge_id: parentChallengeId })
                 .eq('id', challengeId);
+
+            if (linkError) {
+                return NextResponse.json({ success: false, error: 'Failed to link scoring system' }, { status: 500 });
+            }
         }
 
         // Upsert the team score


### PR DESCRIPTION
## Summary
- **publish route**: Sub-team zeroing error now aborts publish (was silently continuing with wrong points)
- **publish route**: Score sync failure caught separately so publish success isn't lost on retry
- **team-score route**: Parent link update error now checked (was creating orphaned rows in specialchallenges)
- **configure-challenges UI**: Removed dead Razorpay code, pricing state, finishDays/finishAmount memos

## Test plan
- [ ] Publish a sub_team challenge — if DB update fails, should return 500 (not publish with wrong points)
- [ ] Assign team score for a challenge with no parent — should not leave orphaned records on link failure
- [ ] Configure challenges page loads without console errors (no missing variable references)
- [ ] Build passes clean (`next build`)