### PR TITLE
Fix challenge leaderboard visibility and scores

### DIFF
--- a/src/app/api/leagues/[id]/challenges/[challengeId]/leaderboard/route.ts
+++ b/src/app/api/leagues/[id]/challenges/[challengeId]/leaderboard/route.ts
@@ -187,47 +187,86 @@ export async function GET(
         .map((item, index) => ({ ...item, rank: index + 1 }));
 
     } else if (challenge.challenge_type === 'sub_team') {
-      // Sub-team challenge - aggregate to TEAM level for leaderboard display
-      // Sub-team scores roll up to their parent team's total
-      const teamScores = new Map<string, { name: string; score: number }>();
+      // Sub-team challenge - check for manually assigned team scores first,
+      // then fall back to aggregating from challenge_submissions.
+      const { data: leagueChallenge } = await supabase
+        .from('leagueschallenges')
+        .select('challenge_id')
+        .eq('id', challengeId)
+        .single();
 
-      // Fetch sub-team to team mapping
-      const subTeamIds = Array.from(new Set((submissions || []).map((s: any) => s.sub_team_id).filter(Boolean)));
-      if (subTeamIds.length > 0) {
-        const { data: subTeams } = await supabase
-          .from('challenge_subteams')
-          .select('subteam_id, team_id, teams(team_name)')
-          .in('subteam_id', subTeamIds);
+      let manualScores: Array<{ team_id: string; score: number }> = [];
 
-        const subTeamToTeamMap = new Map((subTeams || []).map((st: any) => [
-          st.subteam_id,
-          { teamId: st.team_id, teamName: st.teams?.team_name || 'Unknown Team' }
-        ]));
+      if (leagueChallenge?.challenge_id) {
+        const { data: scoresData } = await supabase
+          .from('specialchallengeteamscore')
+          .select('team_id, score')
+          .eq('challenge_id', leagueChallenge.challenge_id)
+          .eq('league_id', leagueId);
 
-        (submissions || []).forEach((sub: any) => {
-          const subTeamId = sub.sub_team_id;
-          if (!subTeamId) return;
+        manualScores = scoresData || [];
+      }
 
-          const points = Number(sub.awarded_points || 0);
-          const teamData = subTeamToTeamMap.get(subTeamId);
-          if (!teamData?.teamId) return;
+      if (manualScores.length > 0) {
+        // Use manual scores
+        const teamIds = manualScores.map(s => s.team_id);
+        const { data: teams } = await supabase
+          .from('teams')
+          .select('team_id, team_name')
+          .in('team_id', teamIds);
 
-          const existing = teamScores.get(teamData.teamId) || { name: teamData.teamName, score: 0 };
-          teamScores.set(teamData.teamId, {
-            ...existing,
-            score: existing.score + points,
-          });
-        });
+        const teamNameMap = new Map((teams || []).map(t => [t.team_id, t.team_name]));
 
-        rankings = Array.from(teamScores.entries())
-          .map(([id, data]) => ({
-            id,
-            name: data.name,
-            score: data.score,
+        rankings = manualScores
+          .map(s => ({
+            id: s.team_id,
+            name: teamNameMap.get(s.team_id) || 'Unknown Team',
+            score: Number(s.score || 0),
             rank: 0,
           }))
           .sort((a, b) => b.score - a.score)
           .map((item, index) => ({ ...item, rank: index + 1 }));
+      } else {
+        // Fall back to submission-based scores
+        const teamScores = new Map<string, { name: string; score: number }>();
+
+        const subTeamIds = Array.from(new Set((submissions || []).map((s: any) => s.sub_team_id).filter(Boolean)));
+        if (subTeamIds.length > 0) {
+          const { data: subTeams } = await supabase
+            .from('challenge_subteams')
+            .select('subteam_id, team_id, teams(team_name)')
+            .in('subteam_id', subTeamIds);
+
+          const subTeamToTeamMap = new Map((subTeams || []).map((st: any) => [
+            st.subteam_id,
+            { teamId: st.team_id, teamName: st.teams?.team_name || 'Unknown Team' }
+          ]));
+
+          (submissions || []).forEach((sub: any) => {
+            const subTeamId = sub.sub_team_id;
+            if (!subTeamId) return;
+
+            const points = Number(sub.awarded_points || 0);
+            const teamData = subTeamToTeamMap.get(subTeamId);
+            if (!teamData?.teamId) return;
+
+            const existing = teamScores.get(teamData.teamId) || { name: teamData.teamName, score: 0 };
+            teamScores.set(teamData.teamId, {
+              ...existing,
+              score: existing.score + points,
+            });
+          });
+
+          rankings = Array.from(teamScores.entries())
+            .map(([id, data]) => ({
+              id,
+              name: data.name,
+              score: data.score,
+              rank: 0,
+            }))
+            .sort((a, b) => b.score - a.score)
+            .map((item, index) => ({ ...item, rank: index + 1 }));
+        }
       }
     } else if (challenge.challenge_type === 'tournament') {
       // Tournament challenge - check for manually assigned scores first

--- a/src/app/api/leagues/[id]/special-challenge-scores/[scId]/route.ts
+++ b/src/app/api/leagues/[id]/special-challenge-scores/[scId]/route.ts
@@ -1,0 +1,74 @@
+/**
+ * GET /api/leagues/[id]/special-challenge-scores/[scId]
+ * Returns team rankings for a specific special challenge by its challenge_id.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth/config';
+import { getSupabaseServiceRole } from '@/lib/supabase/client';
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string; scId: string }> }
+) {
+  try {
+    const session = (await getServerSession(authOptions as any)) as import('next-auth').Session | null;
+    if (!session?.user?.id) {
+      return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id: leagueId, scId: challengeId } = await params;
+    const supabase = getSupabaseServiceRole();
+
+    // Verify membership
+    const { data: membership } = await supabase
+      .from('leaguemembers')
+      .select('league_member_id')
+      .eq('user_id', session.user.id)
+      .eq('league_id', leagueId)
+      .maybeSingle();
+
+    if (!membership) {
+      return NextResponse.json({ success: false, error: 'Not a member' }, { status: 403 });
+    }
+
+    // Fetch team scores for this special challenge
+    const { data: scores, error } = await supabase
+      .from('specialchallengeteamscore')
+      .select('team_id, score')
+      .eq('challenge_id', challengeId)
+      .eq('league_id', leagueId);
+
+    if (error) {
+      return NextResponse.json({ success: false, error: 'Failed to fetch scores' }, { status: 500 });
+    }
+
+    if (!scores || scores.length === 0) {
+      return NextResponse.json({ success: true, data: [] });
+    }
+
+    // Fetch team names
+    const teamIds = scores.map(s => s.team_id);
+    const { data: teams } = await supabase
+      .from('teams')
+      .select('team_id, team_name')
+      .in('team_id', teamIds);
+
+    const teamNameMap = new Map((teams || []).map(t => [t.team_id, t.team_name]));
+
+    const rankings = scores
+      .map(s => ({
+        id: s.team_id,
+        name: teamNameMap.get(s.team_id) || 'Unknown Team',
+        score: Number(s.score || 0),
+        rank: 0,
+      }))
+      .sort((a, b) => b.score - a.score)
+      .map((item, index) => ({ ...item, rank: index + 1 }));
+
+    return NextResponse.json({ success: true, data: rankings });
+  } catch (err) {
+    console.error('Error in special-challenge-scores/[scId]:', err);
+    return NextResponse.json({ success: false, error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/leagues/[id]/special-challenge-scores/route.ts
+++ b/src/app/api/leagues/[id]/special-challenge-scores/route.ts
@@ -1,0 +1,63 @@
+/**
+ * GET /api/leagues/[id]/special-challenge-scores
+ * Returns distinct special challenges that have team scores for this league.
+ * Used by the challenge leaderboard dropdown to show challenges that exist
+ * only in specialchallengeteamscore (not in leagueschallenges).
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth/config';
+import { getSupabaseServiceRole } from '@/lib/supabase/client';
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = (await getServerSession(authOptions as any)) as import('next-auth').Session | null;
+    if (!session?.user?.id) {
+      return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id: leagueId } = await params;
+    const supabase = getSupabaseServiceRole();
+
+    // Verify membership
+    const { data: membership } = await supabase
+      .from('leaguemembers')
+      .select('league_member_id')
+      .eq('user_id', session.user.id)
+      .eq('league_id', leagueId)
+      .maybeSingle();
+
+    if (!membership) {
+      return NextResponse.json({ success: false, error: 'Not a member' }, { status: 403 });
+    }
+
+    // Fetch all special challenge scores for this league with challenge names
+    const { data: scores, error } = await supabase
+      .from('specialchallengeteamscore')
+      .select('challenge_id, specialchallenges(challenge_id, name)')
+      .eq('league_id', leagueId);
+
+    if (error) {
+      return NextResponse.json({ success: false, error: 'Failed to fetch' }, { status: 500 });
+    }
+
+    // Deduplicate by challenge_id
+    const seen = new Set<string>();
+    const challenges: Array<{ challenge_id: string; name: string }> = [];
+    for (const s of scores || []) {
+      const sc = s.specialchallenges as any;
+      if (sc && !seen.has(sc.challenge_id)) {
+        seen.add(sc.challenge_id);
+        challenges.push({ challenge_id: sc.challenge_id, name: sc.name });
+      }
+    }
+
+    return NextResponse.json({ success: true, data: challenges });
+  } catch (err) {
+    console.error('Error in special-challenge-scores:', err);
+    return NextResponse.json({ success: false, error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/components/leaderboard/challenge-specific-leaderboard.tsx
+++ b/src/components/leaderboard/challenge-specific-leaderboard.tsx
@@ -98,19 +98,42 @@ export function ChallengeSpecificLeaderboard({ leagueId, renderViewSwitcher }: C
 
   const selectedChallenge = challenges.find((c) => c.id === selectedChallengeId);
 
-  // Fetch challenges
+  // Fetch challenges (from leagueschallenges + any special-challenge-only entries)
   React.useEffect(() => {
     const fetchChallenges = async () => {
       try {
         const res = await fetch(`/api/leagues/${leagueId}/challenges`);
         const json = await res.json();
+        const visible: Challenge[] = [];
         if (json.success && json.data?.active) {
-          // Filter to only show published/closed challenges in leaderboard
-          const visibleChallenges = (json.data.active as Challenge[]).filter(
-            (c) => c.status === 'published' || c.status === 'closed'
+          // Filter to show challenges that are at least active
+          const fromLeague = (json.data.active as Challenge[]).filter(
+            (c) => c.status === 'active' || c.status === 'submission_closed' || c.status === 'published' || c.status === 'closed'
           );
-          setChallenges(visibleChallenges);
+          visible.push(...fromLeague);
         }
+
+        // Also fetch special challenges that have team scores but aren't in leagueschallenges
+        const scRes = await fetch(`/api/leagues/${leagueId}/special-challenge-scores`);
+        if (scRes.ok) {
+          const scJson = await scRes.json();
+          if (scJson.success && scJson.data) {
+            const existingIds = new Set(visible.map((c) => (c as any).template_id || ''));
+            (scJson.data as Array<{ challenge_id: string; name: string }>).forEach((sc) => {
+              if (!existingIds.has(sc.challenge_id)) {
+                visible.push({
+                  id: `sc_${sc.challenge_id}`,
+                  name: sc.name,
+                  challenge_type: 'team',
+                  total_points: 0,
+                  status: 'closed',
+                });
+              }
+            });
+          }
+        }
+
+        setChallenges(visible);
       } catch (err) {
         console.error('Failed to fetch challenges:', err);
       }
@@ -149,7 +172,15 @@ export function ChallengeSpecificLeaderboard({ leagueId, renderViewSwitcher }: C
       setLoading(true);
       setError(null);
       try {
-        const res = await fetch(`/api/leagues/${leagueId}/challenges/${selectedChallengeId}/leaderboard`);
+        let url: string;
+        if (selectedChallengeId.startsWith('sc_')) {
+          // Special-challenge-only entry — fetch scores directly
+          const scId = selectedChallengeId.replace('sc_', '');
+          url = `/api/leagues/${leagueId}/special-challenge-scores/${scId}`;
+        } else {
+          url = `/api/leagues/${leagueId}/challenges/${selectedChallengeId}/leaderboard`;
+        }
+        const res = await fetch(url);
         const json = await res.json();
         if (!res.ok || !json.success) {
           throw new Error(json.error || 'Failed to fetch scores');


### PR DESCRIPTION
## Summary
- Expand challenge status filter to include `active`/`submission_closed` (was only `published`/`closed`)
- Add `specialchallengeteamscore` fallback for `sub_team` challenge type (same as `tournament` already had)
- Add `special-challenge-scores` API to surface challenges that exist only in `specialchallenges` table
- Support fetching scores for special-challenge-only entries (SJS, Experience Sharing) in the dropdown

## Test plan
- [x] Verified locally on RFL league — NO SJS, Unique Workout Day, SJS, Experience Sharing all show with correct scores