### PR TITLE
Fix monthly multi-activity points and dashboard UI

### DIFF
--- a/src/app/(app)/leagues/[id]/page.tsx
+++ b/src/app/(app)/leagues/[id]/page.tsx
@@ -406,10 +406,13 @@ export default function LeagueDashboardPage({
           recentData?.success && recentData?.data?.submissions ? (recentData.data.submissions as MySubmission[]) : [];
 
         const byDate = new Map<string, MySubmission>();
+        const allByDate = new Map<string, MySubmission[]>();
         const countByDate = new Map<string, number>();
         for (const s of submissions) {
           if (!s?.date) continue;
           countByDate.set(s.date, (countByDate.get(s.date) || 0) + 1);
+          if (!allByDate.has(s.date)) allByDate.set(s.date, []);
+          allByDate.get(s.date)!.push(s);
           const existing = byDate.get(s.date);
           if (!existing) {
             byDate.set(s.date, s);
@@ -446,8 +449,27 @@ export default function LeagueDashboardPage({
           const isAfterEnd = leagueEnd && ymd > leagueEnd;
           const isBeforeStart = leagueStart && ymd < leagueStart;
 
-          // Monthly view: skip any day without a submission
-          if (isMonthlyFrequency && !entry) {
+          // Monthly view: show each submission as its own row
+          if (isMonthlyFrequency) {
+            const dayEntries = allByDate.get(ymd);
+            if (!dayEntries || dayEntries.length === 0) continue;
+
+            for (const sub of dayEntries) {
+              const isWorkout = sub.type === 'workout';
+              const wt = isWorkout
+                ? (sub.custom_activity_name || (sub.workout_type ? String(sub.workout_type).replace(/_/g, ' ') : ''))
+                : '';
+              const tl = isWorkout ? (wt ? wt : 'Workout') : 'Rest Day';
+              const sl = sub.status ? String(sub.status) : '';
+              const st = sl ? `${tl} • ${sl}` : tl;
+              const leagueFormula = (league as any)?.rr_config?.formula || 'standard';
+              const ep = (sub as any).effective_points;
+              const rv = typeof sub.rr_value === 'number' ? sub.rr_value : null;
+              const pl = leagueFormula === 'standard'
+                ? (rv !== null ? `${rv.toFixed(1)} RR` : '0 pt')
+                : `${ep != null ? ep : (rv !== null ? Math.round(rv) : 0)} pt`;
+              rows.push({ date: ymd, label, subtitle: st, status: sl, pointsLabel: pl, submission: sub });
+            }
             continue;
           }
 
@@ -594,19 +616,26 @@ export default function LeagueDashboardPage({
           const approvedSubs = subs.filter((s) => isApproved(s));
           console.log('[MySummary] Approved submissions:', approvedSubs);
 
-          // Deduplicate: only one approved entry per date counts (matches leaderboard logic).
-          // If multiple approved entries exist on the same date (e.g. reupload), keep the one with RR.
-          const uniqueByDate = new Map<string, (typeof approvedSubs)[number]>();
-          approvedSubs.forEach((s) => {
+          // Deduplicate: one approved entry per date+activity (matches leaderboard logic).
+          // Multiple different activities on the same date each count separately.
+          const uniqueByDateActivity = new Map<string, (typeof approvedSubs)[number]>();
+          approvedSubs.forEach((s: any) => {
             const dateKey = String(s.date).slice(0, 10);
-            const existing = uniqueByDate.get(dateKey);
+            const actKey = `${dateKey}_${s.workout_type || ''}`;
+            const existing = uniqueByDateActivity.get(actKey);
             if (!existing || (!existing.rr_value && s.rr_value)) {
-              uniqueByDate.set(dateKey, s);
+              uniqueByDateActivity.set(actKey, s);
             }
           });
-          const dedupedApproved = Array.from(uniqueByDate.values());
+          const dedupedApproved = Array.from(uniqueByDateActivity.values());
 
-          points = dedupedApproved.length;
+          // Use effective_points from API when available (handles outcome-based points)
+          const leagueFormulaSummary = (league as any)?.rr_config?.formula || 'standard';
+          if (leagueFormulaSummary === 'points_only') {
+            points = dedupedApproved.reduce((sum, s: any) => sum + (typeof s.effective_points === 'number' ? s.effective_points : 1), 0);
+          } else {
+            points = dedupedApproved.length;
+          }
           restUsed = dedupedApproved.filter((s) => String(s.type).toLowerCase() === 'rest').length;
 
           const totalRR = dedupedApproved
@@ -625,7 +654,8 @@ export default function LeagueDashboardPage({
             .filter((v) => Number.isFinite(v) && v > 0)
             .reduce((a, b) => a + b, 0);
 
-          avgRR = points > 0 ? Math.round((totalRR / points) * 100) / 100 : null;
+          const rrCount = dedupedApproved.length;
+          avgRR = rrCount > 0 ? Math.round((totalRR / rrCount) * 100) / 100 : null;
 
           // Missed days: from league start through yesterday (local), or league end if earlier.
           const startDt = parseLocalYYYYMMDD(league.start_date);
@@ -873,7 +903,7 @@ export default function LeagueDashboardPage({
         description: (league as any)?.rr_config?.formula === 'standard' || !(league as any)?.rr_config?.formula ? 'Run Rate (approved)' : 'Average score',
         icon: TrendingUp,
       },
-      {
+      ...(league.rest_days > 0 ? [{
         title: 'Rest Days',
         value: `${mySummary.restUsed.toLocaleString()} / ${(mySummary.restUsed + (mySummary.restUnused ?? 0)).toLocaleString()}`,
         changeLabel: 'Used / Total',
@@ -882,14 +912,14 @@ export default function LeagueDashboardPage({
         isCombined: true,
         restUsed: mySummary.restUsed,
         restUnused: mySummary.restUnused,
-      },
-      {
+      }] : []),
+      ...(league.rest_days > 0 ? [{
         title: 'Days Missed',
         value: mySummary.missedDays.toLocaleString(),
         changeLabel: 'Since start',
         description: 'No submission',
         icon: Flame,
-      },
+      }] : []),
     ]
     : null;
 
@@ -1142,65 +1172,85 @@ export default function LeagueDashboardPage({
                 </div>
               </CardHeader>
               <CardContent className="space-y-4">
-                <div className="grid grid-cols-2 gap-3">
-                  <div className="rounded-md border border-primary/20 bg-primary/10 dark:bg-primary/20 px-3 py-2.5 text-center">
-                    <div className="text-xs text-muted-foreground">Total Points</div>
-                    <div className="text-base font-semibold text-foreground tabular-nums">
-                      {mySummary?.points.toLocaleString() ?? '—'}
+                {(() => {
+                  const formula = (league as any)?.rr_config?.formula || 'standard';
+                  const showRR = formula === 'standard';
+                  const showRest = league.rest_days > 0;
+
+                  // Build flat list of stat cells
+                  const cells: React.ReactNode[] = [];
+
+                  cells.push(
+                    <div key="pts" className="rounded-md border border-primary/20 bg-primary/10 dark:bg-primary/20 px-3 py-2.5 text-center">
+                      <div className="text-xs text-muted-foreground">Total Points</div>
+                      <div className="text-base font-semibold text-foreground tabular-nums">
+                        {mySummary?.points.toLocaleString() ?? '—'}
+                      </div>
                     </div>
-                  </div>
-                  {((league as any)?.rr_config?.formula || 'standard') === 'standard' && (
-                  <div className="rounded-md border border-primary/20 bg-primary/10 dark:bg-primary/20 px-3 py-2.5 text-center">
-                    <div className="text-xs text-muted-foreground">Avg RR</div>
-                    <div className="text-base font-semibold text-foreground tabular-nums">
-                      {mySummary?.avgRR !== null && typeof mySummary?.avgRR === 'number'
-                        ? mySummary.avgRR.toFixed(2)
-                        : '—'}
+                  );
+
+                  if (showRR) {
+                    cells.push(
+                      <div key="rr" className="rounded-md border border-primary/20 bg-primary/10 dark:bg-primary/20 px-3 py-2.5 text-center">
+                        <div className="text-xs text-muted-foreground">Avg RR</div>
+                        <div className="text-base font-semibold text-foreground tabular-nums">
+                          {mySummary?.avgRR !== null && typeof mySummary?.avgRR === 'number'
+                            ? mySummary.avgRR.toFixed(2)
+                            : '—'}
+                        </div>
+                        {aiInsights.stat_label_rr && (
+                          <div className="text-[10px] text-amber-600 mt-0.5">{aiInsights.stat_label_rr}</div>
+                        )}
+                      </div>
+                    );
+                  }
+
+                  if (showRest) {
+                    cells.push(
+                      <div key="rest-used" className="rounded-md border border-primary/20 bg-primary/10 dark:bg-primary/20 px-3 py-2.5 text-center">
+                        <div className="text-[11px] text-muted-foreground">Rest Days Used</div>
+                        <div className="text-sm font-semibold text-foreground tabular-nums">
+                          {mySummary?.restUsed.toLocaleString() ?? '—'}
+                        </div>
+                      </div>
+                    );
+                    cells.push(
+                      <div key="rest-rem" className="rounded-md border border-border/60 bg-muted/40 px-3 py-2.5 text-center">
+                        <div className="text-[11px] text-muted-foreground">Rest Days Remaining</div>
+                        <div className="text-sm font-semibold text-foreground tabular-nums">
+                          {mySummary?.restUnused !== null && typeof mySummary?.restUnused === 'number'
+                            ? `${mySummary.restUnused} (of ${league.rest_days})`
+                            : '—'}
+                        </div>
+                      </div>
+                    );
+                    cells.push(
+                      <div key="missed" className="rounded-md border border-border/60 bg-muted/40 px-2.5 py-2.5 text-center">
+                        <div className="text-[11px] text-muted-foreground">Days Missed</div>
+                        <div className="text-sm font-semibold text-foreground tabular-nums">
+                          {mySummary?.missedDays.toLocaleString() ?? '—'}
+                        </div>
+                        {aiInsights.stat_label_missed && (
+                          <div className="text-[10px] text-red-500 mt-0.5">{aiInsights.stat_label_missed}</div>
+                        )}
+                      </div>
+                    );
+                  }
+
+                  cells.push(
+                    <div
+                      key="rejected"
+                      className={`rounded-md border border-border/60 px-3 py-2.5 text-center ${rejectedCount > 0 ? 'bg-destructive/10 dark:bg-destructive/20' : 'bg-muted/40'}`}
+                    >
+                      <div className="text-[11px] text-muted-foreground">Rejected Workouts</div>
+                      <div className="text-sm font-semibold text-foreground tabular-nums">
+                        {rejectedCount.toLocaleString()}
+                      </div>
                     </div>
-                    {aiInsights.stat_label_rr && (
-                      <div className="text-[10px] text-amber-600 mt-0.5">{aiInsights.stat_label_rr}</div>
-                    )}
-                  </div>
-                  )}
-                </div>
-                {league.rest_days > 0 && (
-                <div className="grid grid-cols-2 gap-3">
-                  <div className="rounded-md border border-primary/20 bg-primary/10 dark:bg-primary/20 px-3 py-2.5 text-center">
-                    <div className="text-[11px] text-muted-foreground">Rest Days Used</div>
-                    <div className="text-sm font-semibold text-foreground tabular-nums">
-                      {mySummary?.restUsed.toLocaleString() ?? '—'}
-                    </div>
-                  </div>
-                  <div className="rounded-md border border-border/60 bg-muted/40 px-3 py-2.5 text-center">
-                    <div className="text-[11px] text-muted-foreground">Rest Days Remaining</div>
-                    <div className="text-sm font-semibold text-foreground tabular-nums">
-                      {mySummary?.restUnused !== null && typeof mySummary?.restUnused === 'number'
-                        ? `${mySummary.restUnused} (of ${league.rest_days})`
-                        : '—'}
-                    </div>
-                  </div>
-                </div>
-                )}
-                <div className="grid grid-cols-2 gap-3">
-                  <div className="rounded-md border border-border/60 bg-muted/40 px-2.5 py-2.5 text-center">
-                    <div className="text-[11px] text-muted-foreground">Days Missed</div>
-                    <div className="text-sm font-semibold text-foreground tabular-nums">
-                      {mySummary?.missedDays.toLocaleString() ?? '—'}
-                    </div>
-                    {aiInsights.stat_label_missed && (
-                      <div className="text-[10px] text-red-500 mt-0.5">{aiInsights.stat_label_missed}</div>
-                    )}
-                  </div>
-                  <div
-                    className={`rounded-md border border-border/60 px-3 py-2.5 text-center ${rejectedCount > 0 ? 'bg-destructive/10 dark:bg-destructive/20' : 'bg-muted/40'
-                      }`}
-                  >
-                    <div className="text-[11px] text-muted-foreground">Rejected Workouts</div>
-                    <div className="text-sm font-semibold text-foreground tabular-nums">
-                      {rejectedCount.toLocaleString()}
-                    </div>
-                  </div>
-                </div>
+                  );
+
+                  return <div className="grid grid-cols-2 gap-3">{cells}</div>;
+                })()}
 
                 {((league as any)?.rr_config?.formula || 'standard') === 'standard' && (
                 <div className="rounded-lg border border-border/60 bg-muted/30 p-3">
@@ -1299,34 +1349,39 @@ export default function LeagueDashboardPage({
                 <CardTitle className="text-base">Team Summary</CardTitle>
               </CardHeader>
               <CardContent className="space-y-3">
-                <div className="grid grid-cols-3 gap-3">
-                  <div className="rounded-md border border-primary/20 bg-primary/10 dark:bg-primary/20 px-3 py-2.5 text-center">
-                    <div className="text-xs text-muted-foreground">Total Points</div>
-                    <div className="text-base font-semibold text-foreground tabular-nums">
-                      {typeof mySummary?.teamPoints === 'number'
-                        ? mySummary.teamPoints.toLocaleString()
-                        : '—'}
+                {(() => {
+                  const showTeamRR = ((league as any)?.rr_config?.formula || 'standard') === 'standard';
+                  return (
+                    <div className={`grid ${showTeamRR ? 'grid-cols-3' : 'grid-cols-2'} gap-3`}>
+                      <div className="rounded-md border border-primary/20 bg-primary/10 dark:bg-primary/20 px-3 py-2.5 text-center">
+                        <div className="text-xs text-muted-foreground">Total Points</div>
+                        <div className="text-base font-semibold text-foreground tabular-nums">
+                          {typeof mySummary?.teamPoints === 'number'
+                            ? mySummary.teamPoints.toLocaleString()
+                            : '—'}
+                        </div>
+                      </div>
+                      {showTeamRR && (
+                      <div className="rounded-md border border-border/60 bg-muted/40 px-3 py-2.5 text-center">
+                        <div className="text-xs text-muted-foreground">Run Rate</div>
+                        <div className="text-base font-semibold text-foreground tabular-nums">
+                          {typeof mySummary?.teamAvgRR === 'number'
+                            ? mySummary.teamAvgRR.toFixed(2)
+                            : '—'}
+                        </div>
+                      </div>
+                      )}
+                      <div className="rounded-md border border-border/60 bg-muted/40 px-3 py-2.5 text-center">
+                        <div className="text-xs text-muted-foreground">Team Rank</div>
+                        <div className="text-base font-semibold text-foreground tabular-nums">
+                          {typeof mySummary?.teamRank === 'number'
+                            ? `#${mySummary.teamRank}`
+                            : '—'}
+                        </div>
+                      </div>
                     </div>
-                  </div>
-                  {((league as any)?.rr_config?.formula || 'standard') === 'standard' && (
-                  <div className="rounded-md border border-border/60 bg-muted/40 px-3 py-2.5 text-center">
-                    <div className="text-xs text-muted-foreground">Run Rate</div>
-                    <div className="text-base font-semibold text-foreground tabular-nums">
-                      {typeof mySummary?.teamAvgRR === 'number'
-                        ? mySummary.teamAvgRR.toFixed(2)
-                        : '—'}
-                    </div>
-                  </div>
-                  )}
-                  <div className="rounded-md border border-border/60 bg-muted/40 px-3 py-2.5 text-center">
-                    <div className="text-xs text-muted-foreground">Team Rank</div>
-                    <div className="text-base font-semibold text-foreground tabular-nums">
-                      {typeof mySummary?.teamRank === 'number'
-                        ? `#${mySummary.teamRank}`
-                        : '—'}
-                    </div>
-                  </div>
-                </div>
+                  );
+                })()}
               </CardContent>
             </Card>
           </div>
@@ -1563,8 +1618,8 @@ export default function LeagueDashboardPage({
             </div>
           )}
 
-          {/* Key stats — mobile: 3 rows × 2 cols, tablet/desktop: 2 rows × 3 cols */}
-          <div className="grid grid-cols-2 md:grid-cols-3 divide-x border-b">
+          {/* Key stats row 1: Start Date, End Date, Days Total */}
+          <div className="grid grid-cols-3 divide-x border-b">
             <div className="p-4 flex flex-col items-center text-center">
               <div className="size-10 rounded-lg bg-primary/10 flex items-center justify-center mb-2">
                 <Calendar className="size-5 text-primary" />
@@ -1572,22 +1627,25 @@ export default function LeagueDashboardPage({
               <p className="text-sm font-bold text-primary tabular-nums">{formatDate(league.start_date)}</p>
               <p className="text-xs text-muted-foreground">Start Date</p>
             </div>
-            <div className="p-4 flex flex-col items-center text-center border-b md:border-b-0">
+            <div className="p-4 flex flex-col items-center text-center">
               <div className="size-10 rounded-lg bg-primary/10 flex items-center justify-center mb-2">
                 <Calendar className="size-5 text-primary" />
               </div>
               <p className="text-sm font-bold text-primary tabular-nums">{formatDate(league.end_date)}</p>
               <p className="text-xs text-muted-foreground">End Date</p>
             </div>
-            <div className="p-4 flex flex-col items-center text-center border-b md:border-b-0">
+            <div className="p-4 flex flex-col items-center text-center">
               <div className="size-10 rounded-lg bg-primary/10 flex items-center justify-center mb-2">
                 <Timer className="size-5 text-primary" />
               </div>
               <p className="text-2xl font-bold tabular-nums">{totalDays}</p>
               <p className="text-xs text-muted-foreground">Days Total</p>
             </div>
+          </div>
+          {/* Key stats row 2: Rest Days (if >0), Players, Teams — centered */}
+          <div className={`grid ${league.rest_days > 0 ? 'grid-cols-3' : 'grid-cols-2'} divide-x border-b`}>
             {league.rest_days > 0 && (
-            <div className="p-4 flex flex-col items-center text-center md:border-t">
+            <div className="p-4 flex flex-col items-center text-center">
               <div className="size-10 rounded-lg bg-primary/10 flex items-center justify-center mb-2">
                 <Moon className="size-5 text-primary" />
               </div>
@@ -1595,14 +1653,14 @@ export default function LeagueDashboardPage({
               <p className="text-xs text-muted-foreground">Rest Days</p>
             </div>
             )}
-            <div className="p-4 flex flex-col items-center text-center border-t">
+            <div className="p-4 flex flex-col items-center text-center">
               <div className="size-10 rounded-lg bg-primary/10 flex items-center justify-center mb-2">
                 <Users className="size-5 text-primary" />
               </div>
               <p className="text-2xl font-bold tabular-nums">{league.member_count ?? 0}</p>
               <p className="text-xs text-muted-foreground">Players</p>
             </div>
-            <div className="p-4 flex flex-col items-center text-center border-t">
+            <div className="p-4 flex flex-col items-center text-center">
               <div className="size-10 rounded-lg bg-primary/10 flex items-center justify-center mb-2">
                 <Shield className="size-5 text-primary" />
               </div>

--- a/src/app/(app)/leagues/[id]/submit/page.tsx
+++ b/src/app/(app)/leagues/[id]/submit/page.tsx
@@ -153,6 +153,13 @@ export default function SubmitActivityPage({
     }));
   }, [activitiesData?.activities]);
 
+  // Check if all activities use monthly frequency
+  const isMonthlyFrequency = React.useMemo(() => {
+    const acts = activitiesData?.activities;
+    if (!acts || acts.length === 0) return false;
+    return acts.every((a: any) => a.frequency_type === 'monthly');
+  }, [activitiesData?.activities]);
+
   const [loading, setLoading] = React.useState(false);
   const [submitted, setSubmitted] = React.useState(false);
   const [submittedData, setSubmittedData] = React.useState<any>(null);
@@ -251,6 +258,7 @@ export default function SubmitActivityPage({
 
   // Clamp minimum to yesterday, but if the league ended before that, allow only up to the end date.
   // Exception: If league hasn't started, allow back to 3 days before start (Trial Window).
+  // For monthly frequency: allow any date from league start onwards.
   const minActivityDate = React.useMemo(() => {
     // Trial Mode check:
     if (leagueStartLocal && isBefore(today, leagueStartLocal)) {
@@ -258,10 +266,15 @@ export default function SubmitActivityPage({
       return trialStart;
     }
 
+    // Monthly frequency: allow any date from league start
+    if (isMonthlyFrequency && leagueStartLocal) {
+      return leagueStartLocal;
+    }
+
     if (!maxActivityDate) return yesterday;
     if (isBefore(maxActivityDate, yesterday)) return maxActivityDate;
     return yesterday;
-  }, [maxActivityDate, yesterday, leagueStartLocal, today]);
+  }, [maxActivityDate, yesterday, leagueStartLocal, today, isMonthlyFrequency]);
 
   // Effect to clamp activityDate into the allowed window (yesterday through maxActivityDate)
   // NOTE: activityDate is intentionally NOT in the dependency array to prevent infinite loops.
@@ -719,7 +732,7 @@ export default function SubmitActivityPage({
   const [overwriteDialogOpen, setOverwriteDialogOpen] = React.useState(false);
   const [viewProofUrl, setViewProofUrl] = React.useState<string | null>(null);
 
-  // Check for existing entries when date changes
+  // Check for existing entries when date or selected activity changes
   React.useEffect(() => {
     const checkExisting = async () => {
       if (!leagueId || !activityDate) return;
@@ -736,7 +749,17 @@ export default function SubmitActivityPage({
         if (res.ok && json.success && json.data.submissions.length > 0) {
           const submissions = json.data.submissions;
           setAllDayEntries(submissions);
-          setExistingEntry(submissions[0]);
+
+          // Always scope by activity type when checking for overwrite.
+          // For daily/weekly: only one entry per day exists anyway, so this is safe.
+          // For monthly: multiple activities per day, only flag same activity.
+          if (formData.activity_type) {
+            const sameActivity = submissions.find((s: any) => s.workout_type === formData.activity_type);
+            setExistingEntry(sameActivity || null);
+          } else {
+            // Activity not yet selected — don't flag any existing entry
+            setExistingEntry(null);
+          }
         } else {
           setAllDayEntries([]);
           setExistingEntry(null);
@@ -747,7 +770,7 @@ export default function SubmitActivityPage({
     };
 
     checkExisting();
-  }, [leagueId, activityDate, resubmitId]);
+  }, [leagueId, activityDate, resubmitId, formData.activity_type]);
 
   // For daily multi-frequency activities, determine if more entries are allowed
   const isDailyMultiFrequency = React.useMemo(() => {
@@ -1031,7 +1054,8 @@ export default function SubmitActivityPage({
         proof_url_2: proofUrl2,
         tzOffsetMinutes: new Date().getTimezoneOffset(),
         ianaTimezone: Intl.DateTimeFormat().resolvedOptions().timeZone || null,
-        overwrite: overwrite
+        overwrite: overwrite,
+        ...(overwrite && existingEntry?.id ? { overwrite_entry_id: existingEntry.id } : {}),
       };
 
       // Add relevant metrics based on what was entered
@@ -1524,6 +1548,20 @@ export default function SubmitActivityPage({
                       <span>{format(activityDate, 'MMM d, yyyy')}</span>
                       <Badge variant="secondary" className="text-xs">Locked to original date</Badge>
                     </div>
+                  ) : isMonthlyFrequency ? (
+                    <Input
+                      type="date"
+                      value={format(activityDate, 'yyyy-MM-dd')}
+                      min={minActivityDate ? format(minActivityDate, 'yyyy-MM-dd') : undefined}
+                      max={maxActivityDate ? format(maxActivityDate, 'yyyy-MM-dd') : undefined}
+                      onChange={(e) => {
+                        const val = e.target.value;
+                        if (val) {
+                          const parsed = startOfDay(parseISO(val));
+                          if (!isNaN(parsed.getTime())) setActivityDate(parsed);
+                        }
+                      }}
+                    />
                   ) : (
                     <Select
                       value={isTodaySelected ? 'today' : 'yesterday'}
@@ -2029,11 +2067,11 @@ export default function SubmitActivityPage({
       <AlertDialog open={overwriteDialogOpen} onOpenChange={setOverwriteDialogOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Replace Today's Entry?</AlertDialogTitle>
+            <AlertDialogTitle>Replace {existingEntry?.workout_type ? existingEntry.workout_type.replace(/_/g, ' ') : ''} Entry?</AlertDialogTitle>
             <AlertDialogDescription asChild className="space-y-4 pt-2 text-left">
               <div>
                 <p>
-                  You have already submitted an activity for <strong>{format(activityDate, 'MMMM d, yyyy')}</strong>.
+                  You have already submitted <strong>{existingEntry?.workout_type ? existingEntry.workout_type.replace(/_/g, ' ') : 'an activity'}</strong> for <strong>{format(activityDate, 'MMMM d, yyyy')}</strong>.
                 </p>
 
                 {existingEntry && (
@@ -2113,7 +2151,7 @@ export default function SubmitActivityPage({
                 )}
 
                 <p>
-                  This will replace your earlier entry for today.
+                  This will replace your earlier {existingEntry?.workout_type ? existingEntry.workout_type.replace(/_/g, ' ') : ''} entry for this date.
                 </p>
               </div>
             </AlertDialogDescription>

--- a/src/app/(app)/profile/page.tsx
+++ b/src/app/(app)/profile/page.tsx
@@ -310,7 +310,7 @@ export default function ProfilePage() {
     };
   }, [userLeagues]);
 
-  // Activities logged: one activity per day across all approved submissions in all leagues
+  // Activities logged: count each unique date+activity across all approved submissions in all leagues
   const [activitiesLogged, setActivitiesLogged] = React.useState<number>(0);
   const [activitiesLoading, setActivitiesLoading] = React.useState<boolean>(false);
 
@@ -333,18 +333,18 @@ export default function ProfilePage() {
 
         const results = await Promise.all(promises);
 
-        const dateSet = new Set<string>();
+        const activitySet = new Set<string>();
         for (const res of results) {
           if (res && res.success && Array.isArray(res.data?.submissions)) {
             for (const s of res.data.submissions) {
               if (s && s.date) {
-                dateSet.add(s.date);
+                activitySet.add(`${s.date}_${s.workout_type || ''}`);
               }
             }
           }
         }
 
-        if (mounted) setActivitiesLogged(dateSet.size);
+        if (mounted) setActivitiesLogged(activitySet.size);
       } catch (err) {
         console.error('Error fetching activities for profile:', err);
         if (mounted) setActivitiesLogged(0);

--- a/src/app/api/entries/upsert/route.ts
+++ b/src/app/api/entries/upsert/route.ts
@@ -215,6 +215,9 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    // Track frequency type for duplicate check logic
+    let resolvedFrequencyType: 'daily' | 'weekly' | 'monthly' = 'weekly';
+
     // Enforce per-week activity frequency (if configured)
     if (type === 'workout' && workout_type && !reupload_of) {
       const { data: leagueActivity, error: leagueActivityError } = await supabase
@@ -234,6 +237,7 @@ export async function POST(req: NextRequest) {
       const frequencyType: 'daily' | 'weekly' | 'monthly' =
         rawFrequencyType === 'monthly' ? 'monthly' :
         rawFrequencyType === 'daily' ? 'daily' : 'weekly';
+      resolvedFrequencyType = frequencyType;
       const normalizedFrequency = typeof rawFrequency === 'number' && Number.isFinite(rawFrequency)
         ? Math.floor(rawFrequency)
         : null;
@@ -391,13 +395,22 @@ export async function POST(req: NextRequest) {
     }
 
     // Check for existing entry on same date.
+    // For monthly/daily frequency: scope by workout_type so different activities
+    // can be submitted on the same day without conflict.
     // IMPORTANT: never use maybeSingle() here because duplicates in the database
     // will cause a "multiple rows" error and allow additional inserts.
-    const { data: existingRows, error: existingError } = await supabase
+    let existingQuery = supabase
       .from('effortentry')
       .select('id, type, status, proof_url, created_date, notes')
       .eq('league_member_id', membership.league_member_id)
-      .eq('date', normalizedDate)
+      .eq('date', normalizedDate);
+
+    // For monthly/daily frequency with workouts, only check same activity type
+    if ((resolvedFrequencyType === 'monthly' || resolvedFrequencyType === 'daily') && type === 'workout' && workout_type) {
+      existingQuery = existingQuery.eq('workout_type', workout_type);
+    }
+
+    const { data: existingRows, error: existingError } = await existingQuery
       .order('created_date', { ascending: false });
 
     if (existingError) {

--- a/src/app/api/leagues/[id]/leaderboard/route.ts
+++ b/src/app/api/leagues/[id]/leaderboard/route.ts
@@ -637,12 +637,9 @@ export async function GET(
       // Only care about approved entries for deduplication logic (others don't count anyway)
       if (entry.status !== 'approved') return;
 
-      const key = `${entry.league_member_id}_${entry.date}`;
-      // Logic: If multiple exist, we take the one that exists? 
-      // Summary usually takes the "best" or "latest". 
-      // We'll simplisticly take the first one or latest.
-      // Assuming sorting isn't guaranteed, we just track we have one.
-      // But we need the one with RR value if possible.
+      // Include workout_type in key so multiple different activities on the same day
+      // (e.g. monthly frequency leagues) each count separately.
+      const key = `${entry.league_member_id}_${entry.date}_${entry.workout_type || ''}`;
       const existing = uniqueEntriesMap.get(key);
       if (!existing || (!existing.rr_value && entry.rr_value)) {
         uniqueEntriesMap.set(key, entry);
@@ -697,7 +694,7 @@ export async function GET(
 
       // For points, check against our Unique Map
       if (entry.status === 'approved') {
-        const key = `${entry.league_member_id}_${entry.date}`;
+        const key = `${entry.league_member_id}_${entry.date}_${entry.workout_type || ''}`;
         const unique = uniqueEntriesMap.get(key);
         // Only count if THIS entry is the unique one (by ID)
         if (unique && unique.id === entry.id) {
@@ -757,7 +754,7 @@ export async function GET(
       // Filter entries that are IN the pending window dates.
       const pendingDedup = new Map<string, any>();
       (entries || []).filter(e => pendingWindowDates.includes(e.date) && e.status === 'approved').forEach(e => {
-        const key = `${e.league_member_id}_${e.date}`;
+        const key = `${e.league_member_id}_${e.date}_${e.workout_type || ''}`;
         const existing = pendingDedup.get(key);
         if (!existing || (!existing.rr_value && e.rr_value)) pendingDedup.set(key, e);
       });
@@ -857,7 +854,7 @@ export async function GET(
 
       if (entry.status === 'approved') {
         // Deduplication check: logic matches Team Stats loop above
-        const key = `${entry.league_member_id}_${entry.date}`;
+        const key = `${entry.league_member_id}_${entry.date}_${entry.workout_type || ''}`;
         const unique = uniqueEntriesMap.get(key);
 
         if (unique && unique.id === entry.id) {

--- a/src/app/api/user/rejected-submissions/route.ts
+++ b/src/app/api/user/rejected-submissions/route.ts
@@ -102,7 +102,7 @@ export async function GET(request: NextRequest): Promise<NextResponse<ApiRespons
     // Fetch all entries for these memberships so we can decide per-day latest status.
     const { data: entries, error: entriesError } = await supabase
       .from('effortentry')
-      .select('league_member_id, date, status, created_date, modified_date')
+      .select('league_member_id, date, status, created_date, modified_date, workout_type')
       .in('league_member_id', leagueMemberIds);
 
     if (entriesError) {
@@ -122,14 +122,14 @@ export async function GET(request: NextRequest): Promise<NextResponse<ApiRespons
       })
     );
 
-    // For each (league_member_id, date), take the latest entry and count it as rejected only if that latest status is rejected.
-    type EntryRow = { league_member_id: string; date: string; status: string; created_date: string | null; modified_date: string | null };
+    // For each (league_member_id, date, activity), take the latest entry and count it as rejected only if that latest status is rejected.
+    type EntryRow = { league_member_id: string; date: string; status: string; created_date: string | null; modified_date: string | null; workout_type?: string | null };
     const latestByMemberDate = new Map<string, EntryRow>();
 
     const allEntries = (entries || []) as EntryRow[];
     for (const row of allEntries) {
       if (!row.date || !row.league_member_id) continue;
-      const key = `${row.league_member_id}::${row.date}`;
+      const key = `${row.league_member_id}::${row.date}::${row.workout_type || ''}`;
       const existing = latestByMemberDate.get(key);
       const ts = (row.modified_date || row.created_date || '').toString();
       if (!existing) {

--- a/src/lib/services/league-report.ts
+++ b/src/lib/services/league-report.ts
@@ -220,12 +220,13 @@ export async function getLeagueReportData(
     );
 
     // 10. Calculate performance summary
-    // Deduplicate workout entries by date (only one counts per day, matching leaderboard)
+    // Deduplicate workout entries by date+activity (multiple activities per day each count)
     const workoutEntries = allEntries.filter(e => e.type === 'workout');
     const totalChallengePoints = challenges.reduce((sum, c) => sum + c.pointsEarned, 0);
     const activeDatesSet = new Set(workoutEntries.map(e => e.date));
-    // totalActivities = unique workout dates (not raw entry count)
-    const uniqueWorkoutCount = activeDatesSet.size;
+    // totalActivities = unique date+activity combos (not just unique dates)
+    const uniqueWorkoutKeys = new Set(workoutEntries.map(e => `${e.date}_${(e as any).workout_type || ''}`));
+    const uniqueWorkoutCount = uniqueWorkoutKeys.size;
 
     // Calculate missed days
     // Use date range if provided, otherwise full league duration
@@ -460,7 +461,7 @@ async function getRankings(
     // LOGIC MATCH: Same as /api/leagues/[id]/leaderboard — use points_per_session from leagueactivities
     let entriesQuery = supabase
         .from('effortentry')
-        .select('league_member_id, date, rr_value, workout_type')
+        .select('league_member_id, date, rr_value, workout_type, outcome')
         .eq('status', 'approved')
         .in('league_member_id', memberIds);
 
@@ -470,39 +471,50 @@ async function getRankings(
 
     const { data: allEntries } = await entriesQuery;
 
-    // Fetch activity points configuration for this league
-    const activityPointsMap = new Map<string, number>();
+    // Fetch activity points configuration for this league (including outcome_config)
+    const activityPointsMap = new Map<string, { points_per_session: number; outcome_config: any[] | null }>();
     const { data: laRows } = await supabase
         .from('leagueactivities')
-        .select('activity_id, custom_activity_id, points_per_session, activities(activity_name)')
+        .select('activity_id, custom_activity_id, points_per_session, outcome_config, activities(activity_name)')
         .eq('league_id', leagueId);
     for (const row of (laRows || [])) {
-        const pts = (row as any).points_per_session ?? 1;
+        const config = { points_per_session: (row as any).points_per_session ?? 1, outcome_config: (row as any).outcome_config ?? null };
         if ((row as any).activities?.activity_name) {
-            activityPointsMap.set((row as any).activities.activity_name, pts);
+            activityPointsMap.set((row as any).activities.activity_name, config);
         }
         if (row.custom_activity_id) {
-            activityPointsMap.set(row.custom_activity_id, pts);
+            activityPointsMap.set(row.custom_activity_id, config);
         }
     }
 
-    // Deduplicate: only one entry per date per member (matches leaderboard logic)
+    // Helper to resolve points for an entry (matches leaderboard getEntryPoints)
+    const getEntryPoints = (entry: any): number => {
+        if (!entry.workout_type) return 1;
+        const config = activityPointsMap.get(entry.workout_type);
+        if (!config) return 1;
+        if (config.outcome_config && Array.isArray(config.outcome_config) && entry.outcome) {
+            const match = config.outcome_config.find((o: any) => o.label === entry.outcome);
+            if (match) return match.points;
+        }
+        return config.points_per_session;
+    };
+
+    // Deduplicate: one entry per date per member per activity (matches leaderboard logic)
     const seenMemberDate = new Set<string>();
     const dedupedEntries: typeof allEntries = [];
     for (const entry of (allEntries || [])) {
-        const key = `${entry.league_member_id}:${entry.date}`;
+        const key = `${entry.league_member_id}:${entry.date}:${(entry as any).workout_type || ''}`;
         if (!seenMemberDate.has(key)) {
             seenMemberDate.add(key);
             dedupedEntries.push(entry);
         }
     }
 
-    // Calculate points per member using configured points_per_session
+    // Calculate points per member using configured points (with outcome support)
     const memberPoints = new Map<string, number>();
     for (const entry of dedupedEntries) {
         const current = memberPoints.get(entry.league_member_id) || 0;
-        const pts = (entry as any).workout_type ? (activityPointsMap.get((entry as any).workout_type) ?? 1) : 1;
-        memberPoints.set(entry.league_member_id, current + pts);
+        memberPoints.set(entry.league_member_id, current + getEntryPoints(entry));
     }
 
     // Map user_id to points


### PR DESCRIPTION
## Summary
- Allow multiple different activities per day for monthly frequency leagues
- Fix points calculation across leaderboard, league-report, dashboard, profile, and rejected-submissions (dedup key now includes workout_type)
- Fix submit page overwrite dialog to only trigger for same activity on same date
- Hide Days Missed / Rest Days / Avg RR cards when rest_days=0 or points_only formula
- Fix Team Summary and League Info grid layouts for 2-col when items are hidden

## Test plan
- [ ] Submit multiple different activities on same date (monthly league) — no overwrite dialog
- [ ] Submit same activity on same date — overwrite dialog with activity name
- [ ] Leaderboard shows correct summed points for all activities
- [ ] Dashboard MySummary shows correct total points
- [ ] Dashboard monthly view shows each submission as own row
- [ ] Profile "Activities Logged" counts unique date+activity combos
- [ ] Team Submissions shows all entries separately
- [ ] Reject one activity — only that one rejected, others unaffected
- [ ] points_only + rest_days=0: no Days Missed, Rest Days, or RR cards
- [ ] Team Summary shows 2-col (Total Points + Team Rank) for points_only

🤖 Generated with [Claude Code](https://claude.com/claude-code)