### PR TITLE
Fix frequency enforcement for custom activities

### DIFF
--- a/src/app/api/entries/upsert/route.ts
+++ b/src/app/api/entries/upsert/route.ts
@@ -220,16 +220,37 @@ export async function POST(req: NextRequest) {
 
     // Enforce per-week activity frequency (if configured)
     if (type === 'workout' && workout_type && !reupload_of) {
-      const { data: leagueActivity, error: leagueActivityError } = await supabase
-        .from('leagueactivities')
-        .select('frequency, frequency_type, activities!inner(activity_name)')
-        .eq('league_id', league_id)
-        .eq('activities.activity_name', workout_type)
-        .maybeSingle();
+      // Try global activity lookup first, then custom activity fallback
+      let leagueActivity: any = null;
+      {
+        const { data, error } = await supabase
+          .from('leagueactivities')
+          .select('frequency, frequency_type, activities!inner(activity_name)')
+          .eq('league_id', league_id)
+          .eq('activities.activity_name', workout_type)
+          .maybeSingle();
 
-      if (leagueActivityError) {
-        console.error('League activity lookup error:', leagueActivityError);
-        return NextResponse.json({ error: 'Failed to validate activity frequency' }, { status: 500 });
+        if (error) {
+          console.error('League activity lookup error (global):', error);
+        } else {
+          leagueActivity = data;
+        }
+      }
+
+      // Fallback: custom activity lookup by custom_activity_id (workout_type is UUID for custom activities)
+      if (!leagueActivity) {
+        const { data, error } = await supabase
+          .from('leagueactivities')
+          .select('frequency, frequency_type')
+          .eq('league_id', league_id)
+          .eq('custom_activity_id', workout_type)
+          .maybeSingle();
+
+        if (error) {
+          console.error('League activity lookup error (custom):', error);
+        } else {
+          leagueActivity = data;
+        }
       }
 
       const rawFrequency = (leagueActivity as any)?.frequency ?? null;


### PR DESCRIPTION
## Summary
- Fixed upsert API frequency lookup failing for custom activities (uses `custom_activity_id`, not global `activities` table join)
- Added fallback query by `custom_activity_id` when global activity lookup returns null
- This fixes: frequency limits not enforced for custom activities (e.g., monthly/1 allowed unlimited submissions) and different activities on the same day being incorrectly blocked

## Test plan
- [ ] Submit a custom activity with monthly/1 frequency → should succeed
- [ ] Submit same custom activity again on a different date in same month → should get 409 blocked
- [ ] Submit a different activity on the same date → should succeed without overwrite dialog