### PR TITLE
Fix team points display and workout→activity text

### DIFF
--- a/src/app/(app)/leagues/[id]/my-team-view/page.tsx
+++ b/src/app/(app)/leagues/[id]/my-team-view/page.tsx
@@ -185,7 +185,7 @@ export default function MyTeamViewPage({
     {
       title: 'Activity Points',
       value: typeof teamActivityPoints === 'number' ? teamActivityPoints.toLocaleString() : '—',
-      description: 'Workout points',
+      description: 'Activity points',
       icon: Star,
     },
     {
@@ -200,12 +200,12 @@ export default function MyTeamViewPage({
       description: 'Team total',
       icon: Moon,
     }] : []),
-    {
+    ...(showRestDays ? [{
       title: 'Days Missed',
       value: typeof teamMissedDays === 'number' ? teamMissedDays.toLocaleString() : '—',
       description: 'No submission',
       icon: XCircle,
-    },
+    }] : []),
   ];
 
   // Fetch leaderboard stats for this team
@@ -218,11 +218,16 @@ export default function MyTeamViewPage({
         if (res.ok && json?.success && json.data?.teams) {
           const team = (json.data.teams || []).find((t: any) => String(t.team_id) === String(userTeamId));
           if (team) {
+            // Include pending window points so recently submitted entries are visible
+            const pendingTeam = (json.data?.pendingWindow?.teams || []).find((t: any) => String(t.team_id) === String(userTeamId));
+            const pendingPts = pendingTeam?.total_points ?? 0;
+
             setTeamRank(`#${team.rank ?? '--'}`);
-            const pts = team.total_points ?? team.points ?? 0;
-            setTeamPoints(String(pts));
+            const mainPts = team.total_points ?? team.points ?? 0;
+            setTeamPoints(String(mainPts + pendingPts));
             setTeamAvgRR(String(team.avg_rr ?? 0));
-            setTeamActivityPoints(typeof team.points === 'number' ? Math.max(0, team.points) : null);
+            const activityPts = typeof team.points === 'number' ? Math.max(0, team.points) : 0;
+            setTeamActivityPoints(activityPts + pendingPts);
             setTeamChallengePoints(typeof team.challenge_bonus === 'number' ? Math.max(0, team.challenge_bonus) : null);
           }
         }

--- a/src/app/(app)/leagues/[id]/my-team/page.tsx
+++ b/src/app/(app)/leagues/[id]/my-team/page.tsx
@@ -385,10 +385,13 @@ export default function MyTeamPage({
           const team = teams.find((t) => String(t.team_id) === String(userTeamId));
           console.debug('[MyTeamPage] matched team:', team);
           if (team) {
+            // Include pending window points so recently submitted entries are visible
+            const pendingTeam = (json.data?.pendingWindow?.teams || []).find((t: any) => String(t.team_id) === String(userTeamId));
+            const pendingPts = pendingTeam?.total_points ?? 0;
+
             setTeamRank(`#${team.rank ?? '--'}`);
-            // team.total_points is preferred
-            const pts = team.total_points ?? team.points ?? 0;
-            setTeamPoints(String(pts));
+            const mainPts = team.total_points ?? team.points ?? 0;
+            setTeamPoints(String(mainPts + pendingPts));
             setTeamAvgRR(String(team.avg_rr ?? 0));
           }
         }

--- a/src/components/onboarding/guided-tour.tsx
+++ b/src/components/onboarding/guided-tour.tsx
@@ -47,21 +47,21 @@ const FALLBACK_STEPS: TourStep[] = [
   {
     title: 'Submit Your Activity',
     description:
-      'Log your daily workouts — running, yoga, cycling, gym, and more. Upload a screenshot as proof and the app calculates your effort score (Run Rate) automatically. Consistency is key — submit every day to maximize your team\'s score!',
+      'Log your daily activities — running, yoga, cycling, gym, and more. Upload a screenshot as proof and the app calculates your effort score automatically. Consistency is key — submit every day to maximize your team\'s score!',
     icon_name: 'Dumbbell',
     icon_color: 'text-green-500',
   },
   {
     title: 'Points & Scoring',
     description:
-      'Every approved workout earns you points based on your Run Rate. The harder you push, the more points you earn (up to 2x). Your points add up to your team\'s total on the leaderboard. Team rankings are updated daily!',
+      'Every approved activity earns you points based on your effort. The harder you push, the more points you earn. Your points add up to your team\'s total on the leaderboard. Team rankings are updated daily!',
     icon_name: 'Trophy',
     icon_color: 'text-amber-500',
   },
   {
     title: 'Run Rate (RR)',
     description:
-      'Run Rate measures your workout intensity on a 0-2 scale. An RR of 1.0 means you met the minimum effort — anything above is bonus! RR is calculated from duration, distance, or steps depending on the activity. Age-adjusted thresholds ensure fairness for all.',
+      'Run Rate measures your activity intensity on a 0-2 scale. An RR of 1.0 means you met the minimum effort — anything above is bonus! RR is calculated from duration, distance, or steps depending on the activity. Age-adjusted thresholds ensure fairness for all.',
     icon_name: 'TrendingUp',
     icon_color: 'text-blue-500',
   },

--- a/src/lib/pdf/league-report-pdf.tsx
+++ b/src/lib/pdf/league-report-pdf.tsx
@@ -426,12 +426,12 @@ export function LeagueReportPDF({ data }: LeagueReportPDFProps) {
                             <Text style={styles.sectionTitle}>Performance Overview</Text>
                         </View>
                         <View style={styles.sectionContent}>
-                            <MetricRow label="Workouts Completed" value={data.performance.totalActivities} />
+                            <MetricRow label="Activities Completed" value={data.performance.totalActivities} />
                             <MetricRow label="Points earned for team" value={totalPoints} />
                             {showRestDays && <MetricRow label="Rest Days Taken" value={`${data.restDays.total}${data.restDays.donated ? ` (+ ${data.restDays.donated} donated)` : ''}${data.restDays.received ? ` (+ ${data.restDays.received} received)` : ''}`} />}
                             <MetricRow label="Active Days" value={data.performance.totalActiveDays} />
-                            <MetricRow label="Missed Days" value={data.performance.totalMissedDays} />
-                            <MetricRow label="Best Streak (consecutive workout days)" value={`${bestStreak} Days`} isLast />
+                            {showRestDays && <MetricRow label="Missed Days" value={data.performance.totalMissedDays} />}
+                            <MetricRow label="Best Streak (consecutive activity days)" value={`${bestStreak} Days`} isLast />
                         </View>
                     </View>
 


### PR DESCRIPTION
## Summary
- Include pending window points in team points display so recent submissions show immediately
- Change "Workout points" → "Activity points" label
- Hide Days Missed card when rest_days=0
- Report PDF: "Workouts Completed" → "Activities Completed", hide Missed Days when rest_days=0
- Onboarding fallback text: workouts → activities

## Test plan
- [ ] My Team page shows correct team points (including today/yesterday entries)
- [ ] "Activity points" label shown instead of "Workout points"
- [ ] Days Missed card hidden when rest_days=0
- [ ] Report PDF shows "Activities Completed" and hides Missed Days row