### PR TITLE
Fix duplicate check scoping and team points across app

### DIFF
--- a/src/app/(app)/leagues/[id]/team/page.tsx
+++ b/src/app/(app)/leagues/[id]/team/page.tsx
@@ -123,8 +123,10 @@ function TeamMemberView({
             (t: any) => String(t.team_id) === String(teamId)
           );
           if (team) {
+            const pendingTeam = (leaderboardJson.data?.pendingWindow?.teams || []).find((t: any) => String(t.team_id) === String(teamId));
+            const pendingPts = pendingTeam?.total_points ?? 0;
             setTeamRank(`#${team.rank ?? '--'}`);
-            setTeamPoints(String(team.total_points ?? 0));
+            setTeamPoints(String((team.total_points ?? 0) + pendingPts));
           }
         }
 

--- a/src/app/api/entries/upsert/route.ts
+++ b/src/app/api/entries/upsert/route.ts
@@ -426,8 +426,8 @@ export async function POST(req: NextRequest) {
       .eq('league_member_id', membership.league_member_id)
       .eq('date', normalizedDate);
 
-    // For monthly/daily frequency with workouts, only check same activity type
-    if ((resolvedFrequencyType === 'monthly' || resolvedFrequencyType === 'daily') && type === 'workout' && workout_type) {
+    // For workouts, only check same activity type (different activities on same day are allowed)
+    if (type === 'workout' && workout_type) {
       existingQuery = existingQuery.eq('workout_type', workout_type);
     }
 

--- a/src/app/api/leagues/[id]/manual-entry/route.ts
+++ b/src/app/api/leagues/[id]/manual-entry/route.ts
@@ -246,13 +246,19 @@ export async function POST(
       );
     }
 
-    const { data: existing } = await supabase
+    let existingQuery = supabase
       .from('effortentry')
       .select('id')
       .eq('league_member_id', payload.league_member_id)
       .eq('date', payload.date)
-      .eq('type', payload.type)
-      .maybeSingle();
+      .eq('type', payload.type);
+
+    // For workouts, scope by workout_type so different activities on same day don't conflict
+    if (payload.type === 'workout' && payload.workout_type) {
+      existingQuery = existingQuery.eq('workout_type', payload.workout_type);
+    }
+
+    const { data: existing } = await existingQuery.maybeSingle();
 
     const baseData = {
       date: payload.date,

--- a/src/lib/services/entries.ts
+++ b/src/lib/services/entries.ts
@@ -59,13 +59,19 @@ export async function submitWorkout(
       return null;
     }
 
-    const existing = await getSupabase()
+    let existingQuery = getSupabase()
       .from('effortentry')
       .select('id')
       .eq('league_member_id', leagueMemberId)
       .eq('date', data.date)
-      .eq('type', data.type)
-      .maybeSingle();
+      .eq('type', data.type);
+
+    // For workouts, scope by workout_type so different activities on same day don't conflict
+    if (data.type === 'workout' && data.workout_type) {
+      existingQuery = existingQuery.eq('workout_type', data.workout_type);
+    }
+
+    const existing = await existingQuery.maybeSingle();
 
     if (existing.data) {
       console.warn('Duplicate submission for this date/type');


### PR DESCRIPTION
## Summary
- Scope upsert duplicate check by workout_type for ALL frequency types (was only monthly/daily)
- Add workout_type scoping to manual-entry and entries service duplicate checks
- Include pending window points in team page team points display

## Test plan
- [ ] Submit different activities on same day (any frequency) → no false duplicate blocking
- [ ] Team page shows correct points including recent submissions