### PR TITLE
Fix activities API crash on leagues with custom activities

### DIFF
--- a/src/app/api/leagues/[id]/activities/route.ts
+++ b/src/app/api/leagues/[id]/activities/route.ts
@@ -569,7 +569,7 @@ export async function GET(
             category: null,
             value: customAct.custom_activity_id, // Use ID as value for custom activities to ensure correct lookup
             measurement_type: customAct.measurement_type,
-            settings: activity.settings,
+            settings: null,
             admin_info: null,
             is_custom: true,
             requires_proof: customAct.requires_proof,


### PR DESCRIPTION
Line 572 referenced \ in the custom activities branch where \ is undefined (only defined for global activities at line 587). This crashed the entire GET /api/leagues/[id]/activities endpoint for any league with custom activities, returning 500 Internal Server Error. Changed to \ since custom activities don't have a settings field.