### PR TITLE
Leaderboard cleanup, My League Summary rename, date format fix

### DIFF
--- a/src/app/(app)/leagues/[id]/leaderboard/page.tsx
+++ b/src/app/(app)/leagues/[id]/leaderboard/page.tsx
@@ -245,21 +245,11 @@ export default function LeaderboardPage({ params }: { params: Promise<{ id: stri
           <div className="flex items-center justify-between gap-2 mb-2">
             <div>
               <h1 className="text-xl font-bold tracking-tight">Leaderboard</h1>
-              <div className="flex items-center gap-2">
-                <p className="text-sm text-muted-foreground mr-auto leading-none">
-                  {league?.league_name || 'Rankings'}
-                </p>
-                {normalizationActive && (
-                  <Badge variant="secondary" className="text-[10px] h-5 px-1.5 pointer-events-none">Normalized</Badge>
-                )}
-              </div>
+              <p className="text-sm text-muted-foreground leading-none truncate max-w-[200px]">
+                {league?.league_name || 'Rankings'}
+              </p>
             </div>
             <div className="flex items-center gap-1.5 shrink-0">
-              {normalizationActive && canToggleRaw && (
-                <Button variant="ghost" size="sm" className="h-8 px-2 text-xs" onClick={() => setViewRawTotals(v => !v)}>
-                  {viewRawTotals ? 'Normalized' : 'Raw'}
-                </Button>
-              )}
               <Popover open={filterOpen} onOpenChange={setFilterOpen}>
                 <PopoverTrigger asChild>
                   <Button variant="outline" size="sm" className="h-8 text-xs font-normal shadow-sm hover:shadow">
@@ -366,17 +356,12 @@ export default function LeaderboardPage({ params }: { params: Promise<{ id: stri
               </Button>
             </div>
           </div>
-        </div>
-      </div>
+          <div className="border-t mt-2 pt-3">
 
-      {/* Leaderboards */}
-      <div className="px-4 lg:px-6">
-        
         <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-3">
 
           {/* Teams Leaderboard (Overall) */}
           <TabsContent value="teams" className="mt-0">
-            <div className="rounded-lg border bg-card shadow-sm p-3 sm:p-4">
               <div className="mb-3">
                 <div className="flex items-center justify-between gap-2">
                   <h2 className="text-base sm:text-lg font-semibold">League standings</h2>
@@ -419,7 +404,6 @@ export default function LeaderboardPage({ params }: { params: Promise<{ id: stri
               <div className="overflow-hidden">
                 <LeagueTeamsTable teams={teams} showAvgRR={showRR} />
               </div>
-            </div>
           </TabsContent>
 
           {/* Challenges Leaderboard */}
@@ -459,12 +443,10 @@ export default function LeaderboardPage({ params }: { params: Promise<{ id: stri
             />
           </TabsContent>
         </Tabs>
-      </div>
 
-      {/* Real-time Scoreboard - Always Visible Below Tabs */}
+      {/* Real-time Scoreboard */}
       {pendingWindow?.dates?.length ? (
-        <div className="px-4 lg:px-6">
-          <div className="rounded-lg border bg-card shadow-sm p-3 sm:p-4">
+          <div className="border-t mt-3 pt-3">
             <div className="mb-3">
               <h2 className="text-base sm:text-lg font-semibold">Real-time Scoreboard</h2>
               <p className="text-xs sm:text-sm text-muted-foreground">Today's and yesterday's scores (subject to change)</p>
@@ -473,19 +455,19 @@ export default function LeaderboardPage({ params }: { params: Promise<{ id: stri
               <RealTimeScoreboardTable dates={pendingWindow.dates} teams={pendingWindow.teams || []} showAvgRR={showRR} />
             </div>
           </div>
-        </div>
       ) : null}
 
-      {/* Individual Leaderboard - Always Visible Below Real-time */}
-      <div className="px-4 lg:px-6">
-        <div className="rounded-lg border bg-card shadow-sm p-3 sm:p-4">
-          <div className="mb-3">
-            <h2 className="text-base sm:text-lg font-semibold">Individual Rankings</h2>
-            <p className="text-xs sm:text-sm text-muted-foreground">Top performers</p>
+      {/* Individual Rankings */}
+          <div className="border-t mt-3 pt-3">
+            <div className="mb-3">
+              <h2 className="text-base sm:text-lg font-semibold">Individual Rankings</h2>
+              <p className="text-xs sm:text-sm text-muted-foreground">Top performers</p>
+            </div>
+            <div className="overflow-hidden">
+              <LeagueIndividualsTable individuals={individuals} showAvgRR={showRR} />
+            </div>
           </div>
-          <div className="overflow-hidden">
-            <LeagueIndividualsTable individuals={individuals} showAvgRR={showRR} />
-          </div>
+        </div>
         </div>
       </div>
 

--- a/src/app/(app)/leagues/[id]/page.tsx
+++ b/src/app/(app)/leagues/[id]/page.tsx
@@ -1556,7 +1556,7 @@ export default function LeagueDashboardPage({
                     <ClipboardCheck className="size-6 text-white" />
                   </div>
                   <div className="flex-1 min-w-0">
-                    <h3 className="font-semibold group-hover:text-primary transition-colors">Progress Report</h3>
+                    <h3 className="font-semibold group-hover:text-primary transition-colors">My League Summary</h3>
                     <p className="text-sm text-muted-foreground">Download your latest report</p>
                   </div>
                   <ArrowRight className="size-5 text-muted-foreground group-hover:translate-x-1 group-hover:text-primary transition-all" />
@@ -1624,14 +1624,14 @@ export default function LeagueDashboardPage({
               <div className="size-10 rounded-lg bg-primary/10 flex items-center justify-center mb-2">
                 <Calendar className="size-5 text-primary" />
               </div>
-              <p className="text-sm font-bold text-primary tabular-nums">{formatDate(league.start_date)}</p>
+              <p className="text-sm font-bold text-primary tabular-nums whitespace-nowrap">{formatDate(league.start_date)}</p>
               <p className="text-xs text-muted-foreground">Start Date</p>
             </div>
             <div className="p-4 flex flex-col items-center text-center">
               <div className="size-10 rounded-lg bg-primary/10 flex items-center justify-center mb-2">
                 <Calendar className="size-5 text-primary" />
               </div>
-              <p className="text-sm font-bold text-primary tabular-nums">{formatDate(league.end_date)}</p>
+              <p className="text-sm font-bold text-primary tabular-nums whitespace-nowrap">{formatDate(league.end_date)}</p>
               <p className="text-xs text-muted-foreground">End Date</p>
             </div>
             <div className="p-4 flex flex-col items-center text-center">

--- a/src/components/leagues/dynamic-report-dialog.tsx
+++ b/src/components/leagues/dynamic-report-dialog.tsx
@@ -122,7 +122,7 @@ export function DynamicReportDialog({
             }
 
             const contentDisposition = response.headers.get('Content-Disposition');
-            let filename = 'Progress_Report.pdf';
+            let filename = 'My_League_Summary.pdf';
             if (contentDisposition) {
                 const match = contentDisposition.match(/filename="(.+)"/);
                 if (match) {
@@ -148,13 +148,13 @@ export function DynamicReportDialog({
                 {trigger ?? (
                     <Button variant="outline" size="sm">
                         <IconFileAnalytics className="h-4 w-4 mr-2" />
-                        My League Record
+                        My League Summary
                     </Button>
                 )}
             </DialogTrigger>
             <DialogContent className="sm:max-w-md">
                 <DialogHeader>
-                    <DialogTitle>Generate My League Record</DialogTitle>
+                    <DialogTitle>My League Summary</DialogTitle>
                     <DialogDescription>
                         Choose a date range for your performance report.
                     </DialogDescription>
@@ -217,7 +217,10 @@ export function DynamicReportDialog({
                     )}
                 </div>
 
-                <DialogFooter>
+                <DialogFooter className="gap-2 sm:gap-0">
+                    <Button variant="outline" onClick={() => setOpen(false)} disabled={isLoading}>
+                        Back
+                    </Button>
                     <Button
                         onClick={handleGenerate}
                         disabled={isLoading || !isValid}

--- a/src/lib/pdf/league-report-pdf.tsx
+++ b/src/lib/pdf/league-report-pdf.tsx
@@ -390,7 +390,7 @@ export function LeagueReportPDF({ data }: LeagueReportPDFProps) {
                     <Logo src={data.league.logoUrl} placeholderText="MFL" />
                     <View style={styles.headerCenter}>
                         <Text style={styles.brandText}>MY FITNESS LEAGUE</Text>
-                        <Text style={styles.reportTitle}>My League Record</Text>
+                        <Text style={styles.reportTitle}>My League Summary</Text>
                         <Text style={styles.reportSubtitle}>
                             {formatDate(data.league.startDate)} - {formatDate(data.league.endDate)}
                         </Text>

--- a/src/lib/services/league-report.ts
+++ b/src/lib/services/league-report.ts
@@ -187,8 +187,18 @@ export async function getLeagueReportData(
 
     const allEntries = entries || [];
 
-    // 6. Aggregate activity data
-    const activities = aggregateActivities(allEntries);
+    // 6. Build custom activity name map and aggregate activity data
+    const activityNameMap = new Map<string, string>();
+    const { data: laRows } = await supabase
+        .from('leagueactivities')
+        .select('activity_id, custom_activity_id, activities(activity_name), custom_activities(activity_name)')
+        .eq('league_id', leagueId);
+    for (const row of (laRows || [])) {
+        if ((row as any).custom_activity_id && (row as any).custom_activities?.activity_name) {
+            activityNameMap.set((row as any).custom_activity_id, (row as any).custom_activities.activity_name);
+        }
+    }
+    const activities = aggregateActivities(allEntries, activityNameMap);
 
     // 7. Get rest days + donation info
     const { data: donatedRows } = await supabase
@@ -320,7 +330,7 @@ function calculateBestStreak(activeDates: Set<string>, startDate: Date, endDate:
     return bestStreak;
 }
 
-function aggregateActivities(entries: any[]): ActivitySummary[] {
+function aggregateActivities(entries: any[], activityNameMap?: Map<string, string>): ActivitySummary[] {
     const workoutEntries = entries.filter(e => e.type === 'workout');
 
     const activityMap = new Map<string, {
@@ -332,7 +342,8 @@ function aggregateActivities(entries: any[]): ActivitySummary[] {
     }>();
 
     for (const entry of workoutEntries) {
-        const activityName = entry.workout_type || 'Unknown Activity';
+        const rawType = entry.workout_type || 'Unknown Activity';
+        const activityName = activityNameMap?.get(rawType) || rawType;
         const existing = activityMap.get(activityName) || {
             count: 0,
             totalDuration: 0,


### PR DESCRIPTION
1. Leaderboard: removed Raw/Normalized toggle, fixed league name wrapping, merged all tables into one card
2. Renamed Progress Report to My League Summary (dashboard, dialog, PDF)
3. Added Back button to report dialog
4. Fixed custom activity UUIDs showing in report Activity Details
5. Fixed date format wrapping on dashboard (whitespace-nowrap)