### PR TITLE
Add back navigation on invite pages

### DIFF
--- a/src/app/invite/[code]/page.tsx
+++ b/src/app/invite/[code]/page.tsx
@@ -384,6 +384,13 @@ export default function InvitePage({
             By joining, you agree to participate fairly and follow the league
             rules.
           </p>
+
+          {/* Back to app link */}
+          {session?.user && (
+            <Button variant="ghost" asChild className="w-full">
+              <Link href="/dashboard">Go to Dashboard</Link>
+            </Button>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/src/app/invite/team/[code]/page.tsx
+++ b/src/app/invite/team/[code]/page.tsx
@@ -403,6 +403,13 @@ export default function TeamInvitePage({
             By joining, you agree to participate fairly and follow the league
             rules.
           </p>
+
+          {/* Back to app link */}
+          {session?.user && (
+            <Button variant="ghost" asChild className="w-full">
+              <Link href="/dashboard">Go to Dashboard</Link>
+            </Button>
+          )}
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- Add "Go to Dashboard" link on league and team invite pages for logged-in users
- Previously there was no way to navigate back to the app from the invite page

## Test plan
- [ ] Open an invite link while logged in, verify "Go to Dashboard" button appears below the footer note
- [ ] Click it and verify it navigates to /dashboard
- [ ] Open invite link while logged out, verify the button does not appear