### PR TITLE
Fix team name and activity UUID display issues

### DIFF
--- a/src/app/(app)/leagues/[id]/my-team/page.tsx
+++ b/src/app/(app)/leagues/[id]/my-team/page.tsx
@@ -128,7 +128,8 @@ export default function MyTeamPage({
   const logoInputRef = useRef<HTMLInputElement>(null);
 
   const userTeamId = activeLeague?.team_id;
-  const userTeamName = activeLeague?.team_name;
+  const [freshTeamName, setFreshTeamName] = useState<string | null>(null);
+  const userTeamName = freshTeamName || activeLeague?.team_name;
   const teamCapacity = activeLeague?.league_capacity || 20;
 
   // AI inline insights
@@ -203,6 +204,7 @@ export default function MyTeamPage({
                 const pts2 = team2.total_points ?? team2.points ?? 0;
                 setTeamPoints(String(pts2));
                 setTeamAvgRR(String(team2.avg_rr ?? 0));
+                if (team2.team_name) setFreshTeamName(team2.team_name);
               }
             }
           } catch (err) {

--- a/src/app/(app)/leagues/[id]/submissions/page.tsx
+++ b/src/app/(app)/leagues/[id]/submissions/page.tsx
@@ -101,6 +101,7 @@ interface LeagueSubmission {
   date: string;
   type: 'workout' | 'rest';
   workout_type: string | null;
+  custom_activity_name?: string | null;
   duration: number | null;
   distance: number | null;
   steps: number | null;
@@ -526,7 +527,8 @@ export default function AllSubmissionsPage({
   }, [submissions, statusFilter, teamFilter, dateFilter]);
 
   // Format workout type for display
-  const formatWorkoutType = (type: string | null) => {
+  const formatWorkoutType = (type: string | null, customActivityName?: string | null) => {
+    if (customActivityName) return customActivityName;
     if (!type) return 'General';
     return type
       .split('_')
@@ -598,7 +600,7 @@ export default function AllSubmissionsPage({
             )}
             <span className="text-sm">
               {isWorkout
-                ? formatWorkoutType(row.original.workout_type)
+                ? formatWorkoutType(row.original.workout_type, row.original.custom_activity_name)
                 : isExemption
                   ? 'Exemption Request'
                   : 'Rest Day'}
@@ -993,7 +995,7 @@ export default function AllSubmissionsPage({
                     <div className="flex items-center gap-1.5 text-muted-foreground">
                       {/* Activity Icon Logic */}
                       {submission.type === 'workout' ? <Dumbbell className="size-3.5" /> : <Moon className="size-3.5" />}
-                      <span>{submission.type === 'workout' ? formatWorkoutType(submission.workout_type) : 'Rest Day'}</span>
+                      <span>{submission.type === 'workout' ? formatWorkoutType(submission.workout_type, submission.custom_activity_name) : 'Rest Day'}</span>
                     </div>
                     <div className="scale-90 origin-right">
                       <StatusBadge status={submission.status} />

--- a/src/app/api/leagues/[id]/submissions/route.ts
+++ b/src/app/api/leagues/[id]/submissions/route.ts
@@ -198,10 +198,11 @@ export async function GET(
     // Fetch activity points config for effective_points calculation
     const { data: leagueActivities } = await supabase
       .from('leagueactivities')
-      .select('activity_id, custom_activity_id, points_per_session, outcome_config, activities(activity_name)')
+      .select('activity_id, custom_activity_id, points_per_session, outcome_config, activities(activity_name), custom_activities(activity_name)')
       .eq('league_id', leagueId);
 
     const activityPointsMap = new Map<string, { points_per_session: number; outcome_config: any[] | null }>();
+    const activityNameMap = new Map<string, string>();
     (leagueActivities || []).forEach((row: any) => {
       const config = { points_per_session: row.points_per_session ?? 1, outcome_config: row.outcome_config };
       const key = row.custom_activity_id || row.activity_id;
@@ -209,6 +210,10 @@ export async function GET(
       // Also key by activity name since workout_type stores the name string
       const actName = row.activities?.activity_name;
       if (actName) activityPointsMap.set(actName, config);
+      // Build custom activity name map for UUID resolution
+      if (row.custom_activity_id && (row as any).custom_activities?.activity_name) {
+        activityNameMap.set(row.custom_activity_id, (row as any).custom_activities.activity_name);
+      }
     });
 
     const getEffectivePoints = (entry: any): number => {
@@ -226,6 +231,7 @@ export async function GET(
     let enrichedSubmissions: LeagueSubmission[] = (submissions || []).map((s) => ({
       ...s,
       effective_points: getEffectivePoints(s),
+      custom_activity_name: s.workout_type ? activityNameMap.get(s.workout_type) || null : null,
       member: memberMap.get(s.league_member_id) || {
         user_id: '',
         username: 'Unknown',


### PR DESCRIPTION
## Summary
- Fix My Team page showing stale team name after host renames team (uses fresh name from leaderboard API)
- Fix Validate/Submissions page showing custom activity UUIDs instead of names (resolves via custom_activities table)

## Test plan
- [ ] Rename a team as host, verify My Team page shows updated name
- [ ] Submit a custom activity, verify Validate page shows activity name not UUID