### PR TITLE
Fix: Add inputMode="numeric" to activity input fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix captain permission to only remove members from their own team (#124)
 - Toast scoping: informational toasts auto-dismiss after 4 seconds and all toasts clear on navigation (#151)
 - Fix `use-tournament-matches` and `submissions-table` importing toast directly from sonner, bypassing wrapper duration rules (#151)
+- Add inputMode="decimal" to distance input field for proper mobile keyboard (#133)
 
 ## [2.0.0] — 2026-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Client feedback: filter dropdown, instant messaging UX, left-aligned dropdowns, mobile nav, league info title, and tour flow improvements
 - AI Coach v2.5: inline intelligence replaces standalone AI components
+- Add inputMode="numeric" to activity input fields for improved mobile input experience (#133)
 
 ### Fixed
 - Captain restricted to own team only; removed ability to switch between teams (#1)

--- a/src/app/(app)/leagues/[id]/submit/page.tsx
+++ b/src/app/(app)/leagues/[id]/submit/page.tsx
@@ -1484,6 +1484,7 @@ export default function SubmitActivityPage({
                         <Input
                           id={type}
                           type="number"
+                          inputMode="numeric"
                           min="0"
                           max={type === 'duration' ? '1440' : type === 'distance' ? '1000' : type === 'steps' ? '500000' : type === 'hole' ? '36' : undefined}
                           step={type === 'distance' ? '0.01' : '1'}

--- a/src/app/(app)/leagues/[id]/submit/page.tsx
+++ b/src/app/(app)/leagues/[id]/submit/page.tsx
@@ -1484,7 +1484,7 @@ export default function SubmitActivityPage({
                         <Input
                           id={type}
                           type="number"
-                          inputMode="numeric"
+                          inputMode={type === 'distance' ? 'decimal' : 'numeric'}
                           min="0"
                           max={type === 'duration' ? '1440' : type === 'distance' ? '1000' : type === 'steps' ? '500000' : type === 'hole' ? '36' : undefined}
                           step={type === 'distance' ? '0.01' : '1'}


### PR DESCRIPTION
## Summary
Adds inputMode="numeric" to activity input fields to improve mobile input experience and ensure numeric keyboard usage.


## Related Issue
Partial fix for #133 

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [x] UI/UX improvement
- [ ] Chore (dependencies, config, CI)
- [ ] Documentation

## Changes Made
- Added inputMode="numeric" to activity input fields
- Improves mobile keyboard behavior for numeric inputs

## How to Test
1. Open the activity submission page
2. Focus on numeric input fields (e.g., duration)
3. Verify that numeric input works correctly
4. Inspect the input element to confirm inputMode="numeric" is present


## Checklist
- [x] I have tested this locally and it works
- [x] `pnpm build` passes with no errors
- [x] No `console.log` or commented-out code left behind
- [x] My branch is up to date with `develop`
- [x] I have not modified any files outside the scope of this task
