### PR TITLE
Fix workout attach flow to require explicit selection (#135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+## [Unreleased] — v0.1.0
+
+### Fixed
+- Fix workout attachments in team chat so users choose a specific recent workout before sharing (#135)

--- a/src/components/messaging/message-bubble.tsx
+++ b/src/components/messaging/message-bubble.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useMemo, useState, type ReactNode } from 'react';
 import Link from 'next/link';
 import { Megaphone, ExternalLink, Pencil, Shield, Check, CheckCheck, Reply, SmilePlus } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
@@ -88,6 +88,16 @@ function formatRelativeTime(dateStr: string): string {
  * Strips UUIDs / league IDs so raw database identifiers are never shown.
  */
 function deepLinkLabel(path: string): string {
+  try {
+    const url = new URL(path, 'https://mfl.local');
+    const customLabel = url.searchParams.get('label');
+    if (customLabel) {
+      return customLabel;
+    }
+  } catch {
+    // Fall through to the path-based label mapping.
+  }
+
   // Normalise: remove trailing slash
   const p = path.replace(/\/+$/, '');
 
@@ -119,7 +129,7 @@ function deepLinkLabel(path: string): string {
 
 /** Very lightweight markdown-lite: **bold**, [text](url) links, @[name] mentions */
 function renderContent(content: string) {
-  const parts: (string | JSX.Element)[] = [];
+  const parts: ReactNode[] = [];
   // Matches: **bold**, @[username](user_id) (legacy), @[username] (new), [text](url)
   const regex = /(\*\*(.+?)\*\*)|(@\[([^\]]+)\](?:\([^)]+\))?)|(\[([^\]]+)\]\(([^)]+)\))/g;
   let lastIdx = 0;
@@ -224,13 +234,14 @@ export function MessageBubble({ message, isOwn, currentUserId, onReply, onReact 
       {/* Single self-contained bubble — WhatsApp style */}
       <div
         className={cn(
-          'relative rounded-2xl px-3 py-2 text-sm leading-relaxed whitespace-pre-wrap break-words',
+          'relative rounded-2xl px-3 py-2 text-sm leading-relaxed whitespace-pre-wrap',
           isAnnouncement
             ? 'bg-amber-50 dark:bg-amber-950/40 border border-amber-300 dark:border-amber-700 text-foreground'
             : isOwn
               ? 'bg-primary text-primary-foreground rounded-br-md'
               : 'bg-muted text-foreground rounded-bl-md'
         )}
+        style={{ overflowWrap: 'anywhere' }}
       >
         {/* Sender name + role badge — inside bubble */}
         {!isOwn && (

--- a/src/components/messaging/message-input.tsx
+++ b/src/components/messaging/message-input.tsx
@@ -16,6 +16,7 @@ import {
   Loader2,
   Link2,
 } from 'lucide-react';
+import { format, parseISO } from 'date-fns';
 import { toast } from 'sonner';
 import { useLeague } from '@/contexts/league-context';
 import { Button } from '@/components/ui/button';
@@ -33,8 +34,15 @@ import {
 } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
 import { CannedMessagePicker } from './canned-message-picker';
+import { RecentWorkoutPicker } from './recent-workout-picker';
 import { MentionDropdown, type MentionMember } from './mention-dropdown';
 import type { Message } from './message-bubble';
+
+interface RecentWorkout {
+  id: string;
+  date: string;
+  workout_type: string | null;
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -72,6 +80,7 @@ export function MessageInput({
   const [deepLink, setDeepLink] = useState<string | null>(null);
   const [sending, setSending] = useState(false);
   const [motivating, setMotivating] = useState(false);
+  const [attachMenuOpen, setAttachMenuOpen] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   // Mention state
@@ -263,6 +272,23 @@ export function MessageInput({
     textareaRef.current?.focus();
   };
 
+  const handleWorkoutSelect = (workout: RecentWorkout) => {
+    const workoutLabel = workout.workout_type
+      ? workout.workout_type
+          .split('_')
+          .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+          .join(' ')
+      : 'Workout';
+    const label = `${workoutLabel} • ${format(parseISO(workout.date), 'MMM d')}`;
+    const params = new URLSearchParams({
+      submissionId: workout.id,
+      label,
+    });
+
+    setDeepLink(`/leagues/${leagueId}/submit?${params.toString()}`);
+    setAttachMenuOpen(false);
+  };
+
   return (
     <div className="border-t bg-background px-3 py-2 sm:px-4 sm:py-3">
       {/* Reply preview */}
@@ -417,7 +443,7 @@ export function MessageInput({
         )}
 
         {/* Attach link — popover with selectable options */}
-        <Popover>
+        <Popover open={attachMenuOpen} onOpenChange={setAttachMenuOpen}>
           <PopoverTrigger asChild>
             <Button
               type="button"
@@ -441,24 +467,17 @@ export function MessageInput({
                 Remove attached link
               </button>
             )}
-            <button
-              type="button"
-              className={cn(
-                'w-full flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent',
-                deepLink === `/leagues/${leagueId}/submit` && 'bg-accent font-medium'
-              )}
-              onClick={() => setDeepLink(`/leagues/${leagueId}/submit`)}
-            >
-              <Dumbbell className="size-3.5" />
-              Submit Workout
-            </button>
+            <RecentWorkoutPicker leagueId={leagueId} onSelect={handleWorkoutSelect} />
             <button
               type="button"
               className={cn(
                 'w-full flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent',
                 deepLink === `/leagues/${leagueId}/challenges` && 'bg-accent font-medium'
               )}
-              onClick={() => setDeepLink(`/leagues/${leagueId}/challenges`)}
+              onClick={() => {
+                setDeepLink(`/leagues/${leagueId}/challenges`);
+                setAttachMenuOpen(false);
+              }}
             >
               <Link2 className="size-3.5" />
               Challenges
@@ -469,7 +488,10 @@ export function MessageInput({
                 'w-full flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent',
                 deepLink === `/leagues/${leagueId}/leaderboard` && 'bg-accent font-medium'
               )}
-              onClick={() => setDeepLink(`/leagues/${leagueId}/leaderboard`)}
+              onClick={() => {
+                setDeepLink(`/leagues/${leagueId}/leaderboard`);
+                setAttachMenuOpen(false);
+              }}
             >
               <Link2 className="size-3.5" />
               Leaderboard
@@ -480,7 +502,10 @@ export function MessageInput({
                 'w-full flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent',
                 deepLink === `/leagues/${leagueId}/activities` && 'bg-accent font-medium'
               )}
-              onClick={() => setDeepLink(`/leagues/${leagueId}/activities`)}
+              onClick={() => {
+                setDeepLink(`/leagues/${leagueId}/activities`);
+                setAttachMenuOpen(false);
+              }}
             >
               <Link2 className="size-3.5" />
               Activities
@@ -509,7 +534,7 @@ export function MessageInput({
             onChange={handleContentChange}
             onKeyDown={handleKeyDown}
             placeholder="Type a message... Use @ to mention"
-            className="min-h-[40px] max-h-32 resize-none text-sm py-2"
+            className="min-h-10 max-h-32 resize-none text-sm py-2"
             rows={1}
             disabled={sending}
           />

--- a/src/components/messaging/message-input.tsx
+++ b/src/components/messaging/message-input.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useMemo } from 'react';
 import { useSession } from 'next-auth/react';
 import {
   Send,
@@ -14,7 +14,6 @@ import {
   Dumbbell,
   Zap,
   Loader2,
-  Link2,
 } from 'lucide-react';
 import { format, parseISO } from 'date-fns';
 import { toast } from 'sonner';
@@ -42,6 +41,7 @@ interface RecentWorkout {
   id: string;
   date: string;
   workout_type: string | null;
+  custom_activity_name?: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -95,6 +95,21 @@ export function MessageInput({
   const canMarkImportant = isHostOrGovernor;
   const canAnnounce = isHostOrGovernor;
   const isCaptain = currentRole === 'captain';
+
+  // Memoized label for selected workout deep link
+  const deepLinkLabel = useMemo(() => {
+    if (!deepLink) return null;
+
+    // For workout links, prefer the explicit label passed from picker.
+    if (deepLink.includes('/submit')) {
+      const query = deepLink.split('?')[1] || '';
+      const params = new URLSearchParams(query);
+      const selectedLabel = params.get('label');
+      return selectedLabel || 'Workout';
+    }
+
+    return 'Link';
+  }, [deepLink]);
 
   // Motivate Team — AI-generated message for captains
   const handleMotivateTeam = useCallback(async () => {
@@ -206,12 +221,11 @@ export function MessageInput({
         is_read: true,
         deep_link: deepLink || null,
         parent_message_id: replyTo?.message_id || null,
-        parent_message: replyTo ? { sender_name: replyTo.sender_name || replyTo.sender_username || '', content: replyTo.content } : null,
+        parent_message: replyTo ? { sender_username: replyTo.sender_username || replyTo.sender_name || '', content: replyTo.content } : null,
         created_at: new Date().toISOString(),
         edited_at: null,
-        deleted_at: null,
+        sender_role: currentRole || 'player',
         reactions: [],
-        role: currentRole || 'player',
       };
       onOptimisticMessage(optimistic);
     }
@@ -273,12 +287,12 @@ export function MessageInput({
   };
 
   const handleWorkoutSelect = (workout: RecentWorkout) => {
-    const workoutLabel = workout.workout_type
+    const workoutLabel = workout.custom_activity_name || (workout.workout_type
       ? workout.workout_type
           .split('_')
           .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
           .join(' ')
-      : 'Workout';
+      : 'Workout');
     const label = `${workoutLabel} • ${format(parseISO(workout.date), 'MMM d')}`;
     const params = new URLSearchParams({
       submissionId: workout.id,
@@ -319,7 +333,7 @@ export function MessageInput({
         <div className="flex items-center gap-2 mb-2 px-2 py-1.5 rounded-lg bg-muted/50 border-l-2 border-green-400">
           <Dumbbell className="size-3.5 text-green-500 shrink-0" />
           <span className="text-[11px] text-muted-foreground flex-1 truncate">
-            Workout link attached
+            {deepLinkLabel ? `${deepLinkLabel} link attached` : 'Link attached'}
           </span>
           <button
             type="button"
@@ -442,7 +456,7 @@ export function MessageInput({
           </Button>
         )}
 
-        {/* Attach link — popover with selectable options */}
+        {/* Attach workout — explicit selection via picker */}
         <Popover open={attachMenuOpen} onOpenChange={setAttachMenuOpen}>
           <PopoverTrigger asChild>
             <Button
@@ -450,13 +464,13 @@ export function MessageInput({
               variant="ghost"
               size="icon"
               className={cn('size-8 shrink-0', deepLink && 'text-green-600 dark:text-green-400')}
-              title="Attach a link"
+              title="Attach a workout"
             >
               <Dumbbell className="size-4" />
             </Button>
           </PopoverTrigger>
           <PopoverContent align="start" side="top" className="w-56 p-1">
-            <p className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">Attach a link</p>
+            <p className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">Attach a workout</p>
             {deepLink && (
               <button
                 type="button"
@@ -468,48 +482,6 @@ export function MessageInput({
               </button>
             )}
             <RecentWorkoutPicker leagueId={leagueId} onSelect={handleWorkoutSelect} />
-            <button
-              type="button"
-              className={cn(
-                'w-full flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent',
-                deepLink === `/leagues/${leagueId}/challenges` && 'bg-accent font-medium'
-              )}
-              onClick={() => {
-                setDeepLink(`/leagues/${leagueId}/challenges`);
-                setAttachMenuOpen(false);
-              }}
-            >
-              <Link2 className="size-3.5" />
-              Challenges
-            </button>
-            <button
-              type="button"
-              className={cn(
-                'w-full flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent',
-                deepLink === `/leagues/${leagueId}/leaderboard` && 'bg-accent font-medium'
-              )}
-              onClick={() => {
-                setDeepLink(`/leagues/${leagueId}/leaderboard`);
-                setAttachMenuOpen(false);
-              }}
-            >
-              <Link2 className="size-3.5" />
-              Leaderboard
-            </button>
-            <button
-              type="button"
-              className={cn(
-                'w-full flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent',
-                deepLink === `/leagues/${leagueId}/activities` && 'bg-accent font-medium'
-              )}
-              onClick={() => {
-                setDeepLink(`/leagues/${leagueId}/activities`);
-                setAttachMenuOpen(false);
-              }}
-            >
-              <Link2 className="size-3.5" />
-              Activities
-            </button>
           </PopoverContent>
         </Popover>
 

--- a/src/components/messaging/recent-workout-picker.tsx
+++ b/src/components/messaging/recent-workout-picker.tsx
@@ -18,10 +18,14 @@ import { Separator } from '@/components/ui/separator';
 interface RecentWorkout {
   id: string;
   date: string;
+  type: 'workout' | 'rest';
   workout_type: string | null;
+  custom_activity_name?: string | null;
   status: 'pending' | 'approved' | 'rejected' | 'rejected_resubmit' | 'rejected_permanent';
   duration: number | null;
   distance: number | null;
+  steps?: number | null;
+  holes?: number | null;
   rr_value: number | null;
 }
 
@@ -32,6 +36,12 @@ interface RecentWorkoutPickerProps {
 
 function formatWorkoutType(type: string | null): string {
   if (!type) return 'Workout';
+
+  // If it's a UUID and no custom label was provided, keep the UI readable.
+  if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(type)) {
+    return 'Custom Activity';
+  }
+
   return type
     .split('_')
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
@@ -57,10 +67,9 @@ export function RecentWorkoutPicker({ leagueId, onSelect }: RecentWorkoutPickerP
   const [open, setOpen] = useState(false);
   const [workouts, setWorkouts] = useState<RecentWorkout[]>([]);
   const [loading, setLoading] = useState(false);
-  const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
-    if (!open || loaded) return;
+    if (!open) return;
 
     let cancelled = false;
 
@@ -78,7 +87,6 @@ export function RecentWorkoutPicker({ leagueId, onSelect }: RecentWorkoutPickerP
         const recentWorkouts = raw.filter((entry) => entry.type === 'workout').slice(0, 12);
 
         setWorkouts(recentWorkouts);
-        setLoaded(true);
       } catch {
         if (!cancelled) {
           setWorkouts([]);
@@ -93,7 +101,7 @@ export function RecentWorkoutPicker({ leagueId, onSelect }: RecentWorkoutPickerP
     return () => {
       cancelled = true;
     };
-  }, [leagueId, loaded, open]);
+  }, [leagueId, open]);
 
   return (
     <>
@@ -150,7 +158,7 @@ export function RecentWorkoutPicker({ leagueId, onSelect }: RecentWorkoutPickerP
                     <div className="flex items-center justify-between gap-3">
                       <div className="min-w-0">
                         <p className="truncate text-sm font-medium">
-                          {formatWorkoutType(workout.workout_type)}
+                          {workout.custom_activity_name || formatWorkoutType(workout.workout_type)}
                         </p>
                         <p className="text-xs text-muted-foreground">
                           {formatWorkoutDetails(workout)}

--- a/src/components/messaging/recent-workout-picker.tsx
+++ b/src/components/messaging/recent-workout-picker.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { CalendarDays, Dumbbell, Loader2 } from 'lucide-react';
+import { format, parseISO } from 'date-fns';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Separator } from '@/components/ui/separator';
+
+interface RecentWorkout {
+  id: string;
+  date: string;
+  workout_type: string | null;
+  status: 'pending' | 'approved' | 'rejected' | 'rejected_resubmit' | 'rejected_permanent';
+  duration: number | null;
+  distance: number | null;
+  rr_value: number | null;
+}
+
+interface RecentWorkoutPickerProps {
+  leagueId: string;
+  onSelect: (workout: RecentWorkout) => void;
+}
+
+function formatWorkoutType(type: string | null): string {
+  if (!type) return 'Workout';
+  return type
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+function formatWorkoutDetails(workout: RecentWorkout): string {
+  const parts: string[] = [];
+
+  if (workout.duration !== null) {
+    parts.push(`${workout.duration} min`);
+  } else if (workout.distance !== null) {
+    parts.push(`${workout.distance} distance`);
+  } else if (workout.rr_value !== null) {
+    parts.push(`${workout.rr_value.toFixed(1)} RR`);
+  }
+
+  parts.push(format(parseISO(workout.date), 'MMM d'));
+  return parts.join(' • ');
+}
+
+export function RecentWorkoutPicker({ leagueId, onSelect }: RecentWorkoutPickerProps) {
+  const [open, setOpen] = useState(false);
+  const [workouts, setWorkouts] = useState<RecentWorkout[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!open || loaded) return;
+
+    let cancelled = false;
+
+    const loadWorkouts = async () => {
+      setLoading(true);
+
+      try {
+        const res = await fetch(`/api/leagues/${leagueId}/my-submissions`);
+        if (!res.ok) throw new Error('Failed to load workouts');
+
+        const json = await res.json();
+        if (cancelled) return;
+
+        const raw: RecentWorkout[] = json.data?.submissions ?? json.data ?? [];
+        const recentWorkouts = raw.filter((entry) => entry.type === 'workout').slice(0, 12);
+
+        setWorkouts(recentWorkouts);
+        setLoaded(true);
+      } catch {
+        if (!cancelled) {
+          setWorkouts([]);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    loadWorkouts();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [leagueId, loaded, open]);
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="ghost"
+        className="w-full justify-start gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent"
+        onClick={() => setOpen(true)}
+      >
+        <Dumbbell className="size-3.5" />
+        Choose Workout
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Choose a workout</DialogTitle>
+            <DialogDescription>
+              Pick the recent workout you want to share in chat.
+            </DialogDescription>
+          </DialogHeader>
+
+          <Separator />
+
+          {loading && (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="size-5 animate-spin text-muted-foreground" />
+            </div>
+          )}
+
+          {!loading && workouts.length === 0 && (
+            <div className="flex flex-col items-center justify-center gap-2 py-8 text-center text-muted-foreground">
+              <CalendarDays className="size-8 opacity-40" />
+              <p className="text-sm font-medium">No recent workouts found</p>
+              <p className="text-xs">
+                Submit a workout first, then come back to attach it here.
+              </p>
+            </div>
+          )}
+
+          {!loading && workouts.length > 0 && (
+            <ScrollArea className="max-h-80 pr-3">
+              <div className="space-y-2 py-1">
+                {workouts.map((workout) => (
+                  <button
+                    key={workout.id}
+                    type="button"
+                    className="w-full rounded-lg border px-3 py-2 text-left transition-colors hover:bg-accent"
+                    onClick={() => {
+                      onSelect(workout);
+                      setOpen(false);
+                    }}
+                  >
+                    <div className="flex items-center justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-medium">
+                          {formatWorkoutType(workout.workout_type)}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          {formatWorkoutDetails(workout)}
+                        </p>
+                      </div>
+                      <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                        {workout.status.replace(/_/g, ' ')}
+                      </span>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            </ScrollArea>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}


### PR DESCRIPTION
Fixes the auto-attachment behavior in team chat by requiring explicit workout selection before attaching.

- Deep links remain page-level navigation shortcuts.
- Auto-attachment is fixed: users now explicitly choose a workout before anything attaches.
- Workout picker refreshes on open and shows activity labels when available.

Follow-up (if needed): add record-level deep links with a dedicated effortentry query and link format.