### PR TITLE
Fix/153 captain guidelines bonding automations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Landing page revamp with corporate imagery, orange accent theme, and wearable integration copy
 - V2.5 P0/P1/P2 feature implementation across the platform
 - Add League Ended status badge based on end_date (#150)
+- **Captain Guidelines and pre-launch bonding automations (#153)**
+  - Auto-send welcome message from captain when player joins team
+  - Auto-send team announcement when new member is added
+  - Captain Guidelines document/tooltip accessible in-app with Week 1 focus
+  - System-generated team identity reveal message (team name + logo) on league launch
+  - Messages use team collective language (not individual)
 
 ### Changed
 - Client feedback: filter dropdown, instant messaging UX, left-aligned dropdowns, mobile nav, league info title, and tour flow improvements

--- a/src/app/api/leagues/[id]/launch/route.ts
+++ b/src/app/api/leagues/[id]/launch/route.ts
@@ -5,6 +5,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/lib/auth/config';
 import { launchLeague } from '@/lib/services/leagues';
+import { sendAllTeamIdentityReveals } from '@/lib/services/bonding-automations';
 
 export async function POST(
   request: NextRequest,
@@ -13,19 +14,24 @@ export async function POST(
   try {
     const { id } = await params;
     const session = (await getServerSession(authOptions as any)) as import('next-auth').Session | null;
-    
+
     if (!session?.user?.id) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     const league = await launchLeague(id, session.user.id);
-    
+
     if (!league) {
       return NextResponse.json(
         { error: 'Failed to launch league. Make sure you are the host and the league is in draft status.' },
         { status: 403 }
       );
     }
+
+    // Send team identity reveals for all teams (don't block response)
+    sendAllTeamIdentityReveals(id).catch(error => {
+      console.error('[Bonding] Error sending team identity reveals:', error);
+    });
 
     return NextResponse.json({ data: league, success: true });
   } catch (error) {

--- a/src/app/api/leagues/[id]/teams/[teamId]/captain/route.ts
+++ b/src/app/api/leagues/[id]/teams/[teamId]/captain/route.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 import { assignCaptain, removeCaptain, getTeamMembers } from '@/lib/services/teams';
 import { userHasAnyRole } from '@/lib/services/roles';
 import { getSupabaseServiceRole } from '@/lib/supabase/client';
+import { sendCaptainGuidance } from '@/lib/services/bonding-automations';
 
 // Helper to check if user is league member
 async function isLeagueMember(userId: string, leagueId: string): Promise<boolean> {
@@ -67,6 +68,11 @@ export async function POST(
         { status: 400 }
       );
     }
+
+    // Send captain guidance message (don't block response)
+    sendCaptainGuidance(leagueId, teamId, validated.user_id).catch(error => {
+      console.error('[Bonding] Error sending captain guidance:', error);
+    });
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/leagues/[id]/teams/[teamId]/members/route.ts
+++ b/src/app/api/leagues/[id]/teams/[teamId]/members/route.ts
@@ -14,6 +14,7 @@ import {
 import { getLeagueById } from '@/lib/services/leagues';
 import { userHasAnyRole } from '@/lib/services/roles';
 import { getSupabaseServiceRole } from '@/lib/supabase/client';
+import { sendWelcomeMessage, sendTeamAnnouncement } from '@/lib/services/bonding-automations';
 
 // Helper to check if user is league member
 async function isLeagueMember(userId: string, leagueId: string): Promise<boolean> {
@@ -181,6 +182,28 @@ export async function POST(
         { error: 'Failed to assign member to team' },
         { status: 500 }
       );
+    }
+
+    // Get the newly added member's details for bonding messages
+    const { data: newMember } = await supabase
+      .from('leaguemembers')
+      .select(`
+        user_id,
+        users!leaguemembers_user_id_fkey(username)
+      `)
+      .eq('league_member_id', validated.league_member_id)
+      .single();
+
+    if (newMember?.users) {
+      const memberName = (newMember.users as any).username;
+
+      // Send automated bonding messages (don't block response on these)
+      Promise.all([
+        sendWelcomeMessage(leagueId, teamId, newMember.user_id, memberName),
+        sendTeamAnnouncement(leagueId, teamId, memberName)
+      ]).catch(error => {
+        console.error('[Bonding] Error sending automated messages:', error);
+      });
     }
 
     return NextResponse.json({

--- a/src/components/app/app-sidebar.tsx
+++ b/src/components/app/app-sidebar.tsx
@@ -9,6 +9,8 @@ import {
   MoreVertical,
 } from 'lucide-react';
 
+import { CaptainGuidelinesDialog } from '@/components/captain/captain-guidelines-dialog';
+
 import { useLeague } from '@/contexts/league-context';
 import { useRole } from '@/contexts/role-context';
 import { getSidebarNavItems, NavSection } from '@/lib/navigation/sidebar-config';
@@ -211,6 +213,7 @@ function NavSectionGroup({
   leagueId: string | null;
 }) {
   const { setOpenMobile } = useSidebar();
+  const [captainGuidelinesOpen, setCaptainGuidelinesOpen] = React.useState(false);
 
   return (
     <SidebarGroup>
@@ -228,6 +231,31 @@ function NavSectionGroup({
             ? pathname === item.url
             : pathname === item.url ||
             (!isLeagueRoot && item.url !== '/dashboard' && pathname?.startsWith(item.url));
+
+          // Special handling for Captain Guidelines
+          if (item.url === '#captain-guidelines') {
+            return (
+              <SidebarMenuItem key={item.url}>
+                <CaptainGuidelinesDialog
+                  open={captainGuidelinesOpen}
+                  onOpenChange={setCaptainGuidelinesOpen}
+                  leagueId={leagueId}
+                  trigger={
+                    <SidebarMenuButton
+                      tooltip={item.title}
+                      onClick={() => {
+                        setCaptainGuidelinesOpen(true);
+                        setOpenMobile(false);
+                      }}
+                    >
+                      <item.icon className="size-4" />
+                      <span>{item.title}</span>
+                    </SidebarMenuButton>
+                  }
+                />
+              </SidebarMenuItem>
+            );
+          }
 
           return (
             <SidebarMenuItem key={item.url}>

--- a/src/components/captain/captain-guidelines-dialog.tsx
+++ b/src/components/captain/captain-guidelines-dialog.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import * as React from "react";
-import { Crown, Info, Users, MessageCircle, CheckCircle } from "lucide-react";
+import Link from "next/link";
+import { Crown, Info, Users, MessageCircle, CheckCircle, Calendar, Target, Sparkles, ArrowRight, Clock, Star } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -14,26 +15,47 @@ import {
 } from "@/components/ui/dialog";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
 import { getCaptainGuidelines } from "@/lib/services/bonding-automations";
 
 interface CaptainGuidelinesDialogProps {
     trigger?: React.ReactNode;
     open?: boolean;
     onOpenChange?: (open: boolean) => void;
+    leagueId?: string;
 }
 
 export function CaptainGuidelinesDialog({
     trigger,
     open,
     onOpenChange,
+    leagueId,
 }: CaptainGuidelinesDialogProps) {
     const guidelines = getCaptainGuidelines();
+    const [completedTasks, setCompletedTasks] = React.useState<Set<string>>(new Set());
+
+    const toggleTask = (taskId: string) => {
+        const newCompleted = new Set(completedTasks);
+        if (newCompleted.has(taskId)) {
+            newCompleted.delete(taskId);
+        } else {
+            newCompleted.add(taskId);
+        }
+        setCompletedTasks(newCompleted);
+    };
+
+    const totalTasks = 9; // Total number of actionable tasks
+    const completedCount = completedTasks.size;
+    const progressPercentage = (completedCount / totalTasks) * 100;
 
     const defaultTrigger = (
-        <Button variant="outline" size="sm" className="gap-2">
-            <Crown className="size-4 text-amber-500" />
+        <Button variant="outline" size="sm" className="gap-2 hover:bg-gradient-to-r hover:from-green-50 hover:to-emerald-50 hover:border-green-200 transition-all duration-200 group">
+            <Crown className="size-4 text-green-500 group-hover:text-green-600 transition-colors" />
             Captain Guidelines
-            <Info className="size-3 text-muted-foreground" />
+            <div className="flex items-center">
+                <Sparkles className="size-3 text-green-400 group-hover:text-green-500 transition-colors animate-pulse" />
+            </div>
         </Button>
     );
 
@@ -42,121 +64,202 @@ export function CaptainGuidelinesDialog({
             <DialogTrigger asChild>
                 {trigger || defaultTrigger}
             </DialogTrigger>
-            <DialogContent className="sm:max-w-[600px] max-h-[80vh]">
-                <DialogHeader>
-                    <DialogTitle className="flex items-center gap-2">
-                        <Crown className="size-5 text-amber-500" />
-                        Captain Guidelines - Week 1 Focus
-                    </DialogTitle>
-                    <DialogDescription>
-                        Essential leadership tips for building team spirit and engagement
-                    </DialogDescription>
-                </DialogHeader>
+            <DialogContent className="sm:max-w-[700px] max-h-[85vh] p-0 overflow-hidden rounded-xl">
+                {/* Header with gradient background */}
+                <div className="bg-gradient-to-r from-green-500 via-green-600 to-emerald-600 p-6 text-white rounded-t-xl">
+                    <DialogHeader>
+                        <DialogTitle className="flex items-center gap-3 text-xl font-bold">
+                            <div className="p-2 bg-white/20 rounded-lg backdrop-blur-sm">
+                                <Crown className="size-6" />
+                            </div>
+                            Captain Guidelines - Week 1 Focus
+                        </DialogTitle>
+                        <DialogDescription className="text-green-50 mt-2">
+                            Your roadmap to building an amazing team experience
+                        </DialogDescription>
+                    </DialogHeader>
 
-                <ScrollArea className="max-h-[60vh] pr-4">
+                    {/* Progress tracker */}
+                    <div className="mt-4 p-4 bg-white/10 rounded-lg backdrop-blur-sm">
+                        <div className="flex items-center justify-between mb-2">
+                            <span className="text-sm font-medium text-white">Your Progress</span>
+                            <span className="text-sm text-white">{completedCount}/{totalTasks} tasks</span>
+                        </div>
+                        <Progress value={progressPercentage} className="h-2 bg-white/20 [&>div]:bg-white" />
+                        {completedCount === totalTasks && (
+                            <div className="flex items-center gap-2 mt-2 text-sm">
+                                <Star className="size-4 text-yellow-300" />
+                                <span className="text-yellow-100">Outstanding leadership! 🎉</span>
+                            </div>
+                        )}
+                    </div>
+                </div>
+
+                <ScrollArea className="max-h-[60vh] p-6">
                     <div className="space-y-6">
                         {/* Team Bonding Section */}
-                        <div className="space-y-3">
-                            <div className="flex items-center gap-2">
-                                <Users className="size-5 text-blue-500" />
-                                <h3 className="font-semibold text-base">Team Bonding (Days 1-3)</h3>
-                                <Badge variant="secondary" className="text-xs">Priority</Badge>
-                            </div>
-                            <div className="pl-7 space-y-2 text-sm text-muted-foreground">
-                                <div className="flex items-start gap-2">
-                                    <CheckCircle className="size-4 text-green-500 mt-0.5 shrink-0" />
-                                    <span>Welcome each new member personally</span>
-                                </div>
-                                <div className="flex items-start gap-2">
-                                    <CheckCircle className="size-4 text-green-500 mt-0.5 shrink-0" />
-                                    <span>Share your fitness goals and encourage others to do the same</span>
-                                </div>
-                                <div className="flex items-start gap-2">
-                                    <CheckCircle className="size-4 text-green-500 mt-0.5 shrink-0" />
-                                    <span>Create a positive, supportive team culture</span>
-                                </div>
-                            </div>
-                        </div>
+                        <Card className="border-blue-200 bg-gradient-to-br from-blue-50 to-indigo-50">
+                            <CardHeader className="pb-3">
+                                <CardTitle className="flex items-center gap-3 text-lg">
+                                    <div className="p-2 bg-blue-500 text-white rounded-lg">
+                                        <Users className="size-5" />
+                                    </div>
+                                    <div>
+                                        <div className="flex items-center gap-2">
+                                            Team Bonding
+                                            <Badge variant="secondary" className="bg-blue-100 text-blue-700 text-xs">
+                                                Days 1-3 • Priority
+                                            </Badge>
+                                        </div>
+                                        <div className="flex items-center gap-1 text-sm text-muted-foreground font-normal mt-1">
+                                            <Clock className="size-3" />
+                                            Focus on connection and welcome
+                                        </div>
+                                    </div>
+                                </CardTitle>
+                            </CardHeader>
+                            <CardContent className="space-y-3">
+                                {[
+                                    { id: 'welcome', text: 'Welcome each new member personally', icon: '👋' },
+                                    { id: 'goals', text: 'Share your fitness goals and encourage others to do the same', icon: '🎯' },
+                                    { id: 'culture', text: 'Create a positive, supportive team culture', icon: '💪' }
+                                ].map((task) => (
+                                    <div
+                                        key={task.id}
+                                        className={`flex items-start gap-3 p-3 rounded-lg cursor-pointer transition-all hover:bg-white/60 ${completedTasks.has(task.id) ? 'bg-green-50 border border-green-200' : 'bg-white/40'
+                                            }`}
+                                        onClick={() => toggleTask(task.id)}
+                                    >
+                                        <div className="text-lg">{task.icon}</div>
+                                        <div className="flex-1">
+                                            <span className={`text-sm ${completedTasks.has(task.id) ? 'line-through text-green-700' : ''}`}>
+                                                {task.text}
+                                            </span>
+                                        </div>
+                                        <CheckCircle
+                                            className={`size-5 transition-colors ${completedTasks.has(task.id) ? 'text-green-500' : 'text-gray-300'
+                                                }`}
+                                        />
+                                    </div>
+                                ))}
+                            </CardContent>
+                        </Card>
 
                         {/* Organization Section */}
-                        <div className="space-y-3">
-                            <div className="flex items-center gap-2">
-                                <CheckCircle className="size-5 text-green-500" />
-                                <h3 className="font-semibold text-base">Organization (Days 4-7)</h3>
-                            </div>
-                            <div className="pl-7 space-y-2 text-sm text-muted-foreground">
-                                <div className="flex items-start gap-2">
-                                    <CheckCircle className="size-4 text-green-500 mt-0.5 shrink-0" />
-                                    <span>Help teammates understand league rules and scoring</span>
-                                </div>
-                                <div className="flex items-start gap-2">
-                                    <CheckCircle className="size-4 text-green-500 mt-0.5 shrink-0" />
-                                    <span>Validate workout submissions promptly</span>
-                                </div>
-                                <div className="flex items-start gap-2">
-                                    <CheckCircle className="size-4 text-green-500 mt-0.5 shrink-0" />
-                                    <span>Encourage consistent participation</span>
-                                </div>
-                            </div>
-                        </div>
+                        <Card className="border-green-200 bg-gradient-to-br from-green-50 to-emerald-50">
+                            <CardHeader className="pb-3">
+                                <CardTitle className="flex items-center gap-3 text-lg">
+                                    <div className="p-2 bg-green-500 text-white rounded-lg">
+                                        <Target className="size-5" />
+                                    </div>
+                                    <div>
+                                        <div className="flex items-center gap-2">
+                                            Organization
+                                            <Badge variant="secondary" className="bg-green-100 text-green-700 text-xs">
+                                                Days 4-7
+                                            </Badge>
+                                        </div>
+                                        <div className="flex items-center gap-1 text-sm text-muted-foreground font-normal mt-1">
+                                            <Calendar className="size-3" />
+                                            Structure and systems
+                                        </div>
+                                    </div>
+                                </CardTitle>
+                            </CardHeader>
+                            <CardContent className="space-y-3">
+                                {[
+                                    { id: 'rules', text: 'Help teammates understand league rules and scoring', icon: '📋' },
+                                    { id: 'validate', text: 'Validate workout submissions promptly', icon: '✅' },
+                                    { id: 'participate', text: 'Encourage consistent participation', icon: '🔥' }
+                                ].map((task) => (
+                                    <div
+                                        key={task.id}
+                                        className={`flex items-start gap-3 p-3 rounded-lg cursor-pointer transition-all hover:bg-white/60 ${completedTasks.has(task.id) ? 'bg-green-50 border border-green-200' : 'bg-white/40'
+                                            }`}
+                                        onClick={() => toggleTask(task.id)}
+                                    >
+                                        <div className="text-lg">{task.icon}</div>
+                                        <div className="flex-1">
+                                            <span className={`text-sm ${completedTasks.has(task.id) ? 'line-through text-green-700' : ''}`}>
+                                                {task.text}
+                                            </span>
+                                        </div>
+                                        <CheckCircle
+                                            className={`size-5 transition-colors ${completedTasks.has(task.id) ? 'text-green-500' : 'text-gray-300'
+                                                }`}
+                                        />
+                                    </div>
+                                ))}
+                            </CardContent>
+                        </Card>
 
                         {/* Communication Section */}
-                        <div className="space-y-3">
-                            <div className="flex items-center gap-2">
-                                <MessageCircle className="size-5 text-purple-500" />
-                                <h3 className="font-semibold text-base">Communication Tips</h3>
-                            </div>
-                            <div className="pl-7 space-y-2 text-sm text-muted-foreground">
-                                <div className="flex items-start gap-2">
-                                    <CheckCircle className="size-4 text-green-500 mt-0.5 shrink-0" />
-                                    <span>Check in with quiet team members</span>
-                                </div>
-                                <div className="flex items-start gap-2">
-                                    <CheckCircle className="size-4 text-green-500 mt-0.5 shrink-0" />
-                                    <span>Celebrate small wins and progress</span>
-                                </div>
-                                <div className="flex items-start gap-2">
-                                    <CheckCircle className="size-4 text-green-500 mt-0.5 shrink-0" />
-                                    <span>Address any concerns quickly and positively</span>
-                                </div>
-                            </div>
-                        </div>
+                        <Card className="border-purple-200 bg-gradient-to-br from-purple-50 to-violet-50">
+                            <CardHeader className="pb-3">
+                                <CardTitle className="flex items-center gap-3 text-lg">
+                                    <div className="p-2 bg-purple-500 text-white rounded-lg">
+                                        <MessageCircle className="size-5" />
+                                    </div>
+                                    <div>
+                                        <div className="flex items-center gap-2">
+                                            Communication Tips
+                                            <Badge variant="secondary" className="bg-purple-100 text-purple-700 text-xs">
+                                                Ongoing
+                                            </Badge>
+                                        </div>
+                                        <div className="flex items-center gap-1 text-sm text-muted-foreground font-normal mt-1">
+                                            <MessageCircle className="size-3" />
+                                            Keep the team connected
+                                        </div>
+                                    </div>
+                                </CardTitle>
+                            </CardHeader>
+                            <CardContent className="space-y-3">
+                                {[
+                                    { id: 'checkin', text: 'Check in with quiet team members', icon: '🤝' },
+                                    { id: 'celebrate', text: 'Celebrate small wins and progress', icon: '🎉' },
+                                    { id: 'address', text: 'Address any concerns quickly and positively', icon: '💬' }
+                                ].map((task) => (
+                                    <div
+                                        key={task.id}
+                                        className={`flex items-start gap-3 p-3 rounded-lg cursor-pointer transition-all hover:bg-white/60 ${completedTasks.has(task.id) ? 'bg-green-50 border border-green-200' : 'bg-white/40'
+                                            }`}
+                                        onClick={() => toggleTask(task.id)}
+                                    >
+                                        <div className="text-lg">{task.icon}</div>
+                                        <div className="flex-1">
+                                            <span className={`text-sm ${completedTasks.has(task.id) ? 'line-through text-green-700' : ''}`}>
+                                                {task.text}
+                                            </span>
+                                        </div>
+                                        <CheckCircle
+                                            className={`size-5 transition-colors ${completedTasks.has(task.id) ? 'text-green-500' : 'text-gray-300'
+                                                }`}
+                                        />
+                                    </div>
+                                ))}
+                            </CardContent>
+                        </Card>
 
                         {/* Leadership Impact */}
-                        <div className="rounded-lg bg-gradient-to-r from-amber-50 to-orange-50 dark:from-amber-950/20 dark:to-orange-950/20 p-4 border border-amber-200 dark:border-amber-800">
-                            <div className="flex items-start gap-3">
-                                <Crown className="size-5 text-amber-500 mt-0.5 shrink-0" />
-                                <div>
-                                    <p className="font-medium text-sm text-amber-900 dark:text-amber-100">
-                                        Your Leadership Impact
-                                    </p>
-                                    <p className="text-sm text-amber-700 dark:text-amber-200 mt-1">
-                                        Your leadership sets the tone for the entire team's experience! A positive,
-                                        engaged captain creates a motivated team that supports each other throughout
-                                        the league.
-                                    </p>
-                                </div>
-                            </div>
-                        </div>
-
-                        {/* Quick Actions */}
-                        <div className="space-y-3">
-                            <h3 className="font-semibold text-base">Quick Actions You Can Take Now</h3>
-                            <div className="grid grid-cols-1 gap-2 text-sm">
-                                <div className="flex items-center gap-2 p-2 rounded-md bg-muted/50">
-                                    <MessageCircle className="size-4 text-blue-500" />
-                                    <span>Send a welcome message to your team chat</span>
-                                </div>
-                                <div className="flex items-center gap-2 p-2 rounded-md bg-muted/50">
-                                    <Users className="size-4 text-green-500" />
-                                    <span>Ask each member to share their fitness goals</span>
-                                </div>
-                                <div className="flex items-center gap-2 p-2 rounded-md bg-muted/50">
-                                    <CheckCircle className="size-4 text-purple-500" />
-                                    <span>Review league rules and scoring system</span>
-                                </div>
-                            </div>
-                        </div>
+                        <Card className="border-green-200 bg-gradient-to-br from-green-50 via-emerald-50 to-teal-50 overflow-hidden relative">
+                            <div className="absolute top-0 right-0 w-32 h-32 bg-gradient-to-bl from-green-200/30 to-transparent rounded-full -translate-y-16 translate-x-16"></div>
+                            <CardHeader>
+                                <CardTitle className="flex items-center gap-3 text-lg">
+                                    <div className="p-2 bg-gradient-to-r from-green-500 to-emerald-500 text-white rounded-lg">
+                                        <Crown className="size-5" />
+                                    </div>
+                                    Your Leadership Impact
+                                </CardTitle>
+                            </CardHeader>
+                            <CardContent>
+                                <p className="text-sm text-green-800 leading-relaxed">
+                                    Your leadership sets the tone for the entire team's experience! A positive, engaged captain
+                                    creates a motivated team that supports each other throughout the league.
+                                    <span className="font-semibold"> You're the spark that ignites team spirit! ✨</span>
+                                </p>
+                            </CardContent>
+                        </Card>
                     </div>
                 </ScrollArea>
             </DialogContent>

--- a/src/components/captain/captain-guidelines-dialog.tsx
+++ b/src/components/captain/captain-guidelines-dialog.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import * as React from "react";
+import { Crown, Info, Users, MessageCircle, CheckCircle } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "@/components/ui/dialog";
+import { Badge } from "@/components/ui/badge";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { getCaptainGuidelines } from "@/lib/services/bonding-automations";
+
+interface CaptainGuidelinesDialogProps {
+    trigger?: React.ReactNode;
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+}
+
+export function CaptainGuidelinesDialog({
+    trigger,
+    open,
+    onOpenChange,
+}: CaptainGuidelinesDialogProps) {
+    const guidelines = getCaptainGuidelines();
+
+    const defaultTrigger = (
+        <Button variant="outline" size="sm" className="gap-2">
+            <Crown className="size-4 text-amber-500" />
+            Captain Guidelines
+            <Info className="size-3 text-muted-foreground" />
+        </Button>
+    );
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogTrigger asChild>
+                {trigger || defaultTrigger}
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-[600px] max-h-[80vh]">
+                <DialogHeader>
+                    <DialogTitle className="flex items-center gap-2">
+                        <Crown className="size-5 text-amber-500" />
+                        Captain Guidelines - Week 1 Focus
+                    </DialogTitle>
+                    <DialogDescription>
+                        Essential leadership tips for building team spirit and engagement
+                    </DialogDescription>
+                </DialogHeader>
+
+                <ScrollArea className="max-h-[60vh] pr-4">
+                    <div className="space-y-6">
+                        {/* Team Bonding Section */}
+                        <div className="space-y-3">
+                            <div className="flex items-center gap-2">
+                                <Users className="size-5 text-blue-500" />
+                                <h3 className="font-semibold text-base">Team Bonding (Days 1-3)</h3>
+                                <Badge variant="secondary" className="text-xs">Priority</Badge>
+                            </div>
+                            <div className="pl-7 space-y-2 text-sm text-muted-foreground">
+                                <div className="flex items-start gap-2">
+                                    <CheckCircle className="size-4 text-green-500 mt-0.5 shrink-0" />
+                                    <span>Welcome each new member personally</span>
+                                </div>
+                                <div className="flex items-start gap-2">
+                                    <CheckCircle className="size-4 text-green-500 mt-0.5 shrink-0" />
+                                    <span>Share your fitness goals and encourage others to do the same</span>
+                                </div>
+                                <div className="flex items-start gap-2">
+                                    <CheckCircle className="size-4 text-green-500 mt-0.5 shrink-0" />
+                                    <span>Create a positive, supportive team culture</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        {/* Organization Section */}
+                        <div className="space-y-3">
+                            <div className="flex items-center gap-2">
+                                <CheckCircle className="size-5 text-green-500" />
+                                <h3 className="font-semibold text-base">Organization (Days 4-7)</h3>
+                            </div>
+                            <div className="pl-7 space-y-2 text-sm text-muted-foreground">
+                                <div className="flex items-start gap-2">
+                                    <CheckCircle className="size-4 text-green-500 mt-0.5 shrink-0" />
+                                    <span>Help teammates understand league rules and scoring</span>
+                                </div>
+                                <div className="flex items-start gap-2">
+                                    <CheckCircle className="size-4 text-green-500 mt-0.5 shrink-0" />
+                                    <span>Validate workout submissions promptly</span>
+                                </div>
+                                <div className="flex items-start gap-2">
+                                    <CheckCircle className="size-4 text-green-500 mt-0.5 shrink-0" />
+                                    <span>Encourage consistent participation</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        {/* Communication Section */}
+                        <div className="space-y-3">
+                            <div className="flex items-center gap-2">
+                                <MessageCircle className="size-5 text-purple-500" />
+                                <h3 className="font-semibold text-base">Communication Tips</h3>
+                            </div>
+                            <div className="pl-7 space-y-2 text-sm text-muted-foreground">
+                                <div className="flex items-start gap-2">
+                                    <CheckCircle className="size-4 text-green-500 mt-0.5 shrink-0" />
+                                    <span>Check in with quiet team members</span>
+                                </div>
+                                <div className="flex items-start gap-2">
+                                    <CheckCircle className="size-4 text-green-500 mt-0.5 shrink-0" />
+                                    <span>Celebrate small wins and progress</span>
+                                </div>
+                                <div className="flex items-start gap-2">
+                                    <CheckCircle className="size-4 text-green-500 mt-0.5 shrink-0" />
+                                    <span>Address any concerns quickly and positively</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        {/* Leadership Impact */}
+                        <div className="rounded-lg bg-gradient-to-r from-amber-50 to-orange-50 dark:from-amber-950/20 dark:to-orange-950/20 p-4 border border-amber-200 dark:border-amber-800">
+                            <div className="flex items-start gap-3">
+                                <Crown className="size-5 text-amber-500 mt-0.5 shrink-0" />
+                                <div>
+                                    <p className="font-medium text-sm text-amber-900 dark:text-amber-100">
+                                        Your Leadership Impact
+                                    </p>
+                                    <p className="text-sm text-amber-700 dark:text-amber-200 mt-1">
+                                        Your leadership sets the tone for the entire team's experience! A positive,
+                                        engaged captain creates a motivated team that supports each other throughout
+                                        the league.
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+
+                        {/* Quick Actions */}
+                        <div className="space-y-3">
+                            <h3 className="font-semibold text-base">Quick Actions You Can Take Now</h3>
+                            <div className="grid grid-cols-1 gap-2 text-sm">
+                                <div className="flex items-center gap-2 p-2 rounded-md bg-muted/50">
+                                    <MessageCircle className="size-4 text-blue-500" />
+                                    <span>Send a welcome message to your team chat</span>
+                                </div>
+                                <div className="flex items-center gap-2 p-2 rounded-md bg-muted/50">
+                                    <Users className="size-4 text-green-500" />
+                                    <span>Ask each member to share their fitness goals</span>
+                                </div>
+                                <div className="flex items-center gap-2 p-2 rounded-md bg-muted/50">
+                                    <CheckCircle className="size-4 text-purple-500" />
+                                    <span>Review league rules and scoring system</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </ScrollArea>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+export default CaptainGuidelinesDialog;

--- a/src/components/captain/captain-guidelines-tooltip.tsx
+++ b/src/components/captain/captain-guidelines-tooltip.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import * as React from "react";
+import { Crown, Info } from "lucide-react";
+
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Button } from "@/components/ui/button";
+import { CaptainGuidelinesDialog } from "./captain-guidelines-dialog";
+
+interface CaptainGuidelinesTooltipProps {
+    children?: React.ReactNode;
+}
+
+export function CaptainGuidelinesTooltip({ children }: CaptainGuidelinesTooltipProps) {
+    const [dialogOpen, setDialogOpen] = React.useState(false);
+
+    const trigger = children || (
+        <Button variant="ghost" size="sm" className="gap-1 text-muted-foreground hover:text-amber-600">
+            <Crown className="size-3" />
+            <Info className="size-3" />
+        </Button>
+    );
+
+    return (
+        <TooltipProvider>
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <div onClick={() => setDialogOpen(true)} className="cursor-pointer">
+                        {trigger}
+                    </div>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="max-w-xs">
+                    <div className="space-y-1">
+                        <p className="font-medium text-xs">Captain Guidelines</p>
+                        <p className="text-xs text-muted-foreground">
+                            Week 1 focus: Team bonding, organization, and communication tips
+                        </p>
+                        <p className="text-xs text-amber-600">Click to view full guidelines</p>
+                    </div>
+                </TooltipContent>
+            </Tooltip>
+
+            <CaptainGuidelinesDialog
+                open={dialogOpen}
+                onOpenChange={setDialogOpen}
+            />
+        </TooltipProvider>
+    );
+}
+
+export default CaptainGuidelinesTooltip;

--- a/src/components/teams/teams-table.tsx
+++ b/src/components/teams/teams-table.tsx
@@ -78,6 +78,7 @@ import { ViewUnallocatedDialog } from "./view-unallocated-dialog";
 import { ViewTeamMembersDialog } from "./view-team-members-dialog";
 import { TeamInviteDialog } from "./team-invite-dialog";
 import { InviteDialog } from "@/components/league/invite-dialog";
+import { CaptainGuidelinesTooltip } from "@/components/captain/captain-guidelines-tooltip";
 
 import {
   useLeagueTeams,
@@ -421,7 +422,12 @@ export function TeamsTable({ leagueId, isHost, isGovernor }: TeamsTableProps) {
     },
     {
       accessorKey: "captain",
-      header: "Captain",
+      header: () => (
+        <div className="flex items-center gap-1">
+          Captain
+          <CaptainGuidelinesTooltip />
+        </div>
+      ),
       cell: ({ row }) => {
         const captain = row.original.captain;
         if (!captain) {
@@ -619,7 +625,7 @@ export function TeamsTable({ leagueId, isHost, isGovernor }: TeamsTableProps) {
                 leagueId={leagueId}
                 leagueName={data.league.league_name}
                 inviteCode={data.league.invite_code || ''}
-                memberCount={data.meta.member_count}
+                memberCount={data.members.allocated.length + data.members.unallocated.length}
                 maxCapacity={data.league.league_capacity || 20}
                 buttonLabel="League Invite"
               />

--- a/src/components/teams/view-team-members-dialog.tsx
+++ b/src/components/teams/view-team-members-dialog.tsx
@@ -35,6 +35,7 @@ import {
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { toast } from "@/lib/toast";
 import type { TeamMember } from "@/hooks/use-league-teams";
+import { CaptainGuidelinesTooltip } from "@/components/captain/captain-guidelines-tooltip";
 
 interface ViewTeamMembersDialogProps {
   open: boolean;
@@ -203,7 +204,12 @@ export function ViewTeamMembersDialog({
             {members.length > 0
               ? `${members.length} member${members.length !== 1 ? "s" : ""} in this team`
               : "No members in this team yet"}
-            {captain && ` | Captain: ${captain.username}`}
+            {captain && (
+              <span className="flex items-center gap-1 mt-1">
+                Captain: {captain.username}
+                <CaptainGuidelinesTooltip />
+              </span>
+            )}
           </DialogDescription>
         </DialogHeader>
 

--- a/src/lib/navigation/sidebar-config.ts
+++ b/src/lib/navigation/sidebar-config.ts
@@ -255,6 +255,11 @@ export function getSidebarNavItems(
           url: leagueUrl('/rest-day-donations'),
           icon: HeartHandshake,
         },
+        {
+          title: 'Captain Guidelines',
+          url: '#captain-guidelines',
+          icon: BookOpen,
+        },
       ],
     });
   }

--- a/src/lib/services/bonding-automations.ts
+++ b/src/lib/services/bonding-automations.ts
@@ -1,0 +1,315 @@
+/**
+ * Bonding Automations Service - Automated team bonding messages and captain guidance
+ * Handles welcome messages, member announcements, and team identity reveals
+ */
+import { getSupabaseServiceRole } from '@/lib/supabase/client';
+import { sendMessage } from '@/lib/services/messages';
+import { getTeamMembers } from '@/lib/services/teams';
+import { getLeagueById } from '@/lib/services/leagues';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface TeamIdentity {
+    team_name: string;
+    team_logo_url?: string;
+    team_id: string;
+    member_count: number;
+    captain_name?: string;
+}
+
+export interface BondingMessageTemplate {
+    welcome_new_member: string;
+    team_announcement: string;
+    team_identity_reveal: string;
+    captain_guidance: string;
+}
+
+// ============================================================================
+// Message Templates
+// ============================================================================
+
+const BONDING_TEMPLATES: BondingMessageTemplate = {
+    welcome_new_member: `🎉 **Welcome to the team, {member_name}!**
+
+We're excited to have you join us! Here's what you need to know:
+
+• **Team Goal**: Work together to achieve our fitness targets
+• **Support**: Your teammates are here to motivate and encourage you
+• **Communication**: Use this chat to share progress, ask questions, and celebrate wins
+
+Let's make this league amazing together! 💪`,
+
+    team_announcement: `👋 **Team Update**
+
+{member_name} has joined our squad! Let's give them a warm welcome.
+
+Our team now has **{member_count} members** ready to crush this league together! 🔥`,
+
+    team_identity_reveal: `🏆 **Meet Your Team: {team_name}**
+
+Your team is officially formed and ready for action! Here's your squad:
+
+{member_list}
+
+**Captain**: {captain_name}
+
+Time to bond, support each other, and show everyone what {team_name} can do! 
+
+Good luck, team! 🚀`,
+
+    captain_guidance: `👑 **Captain Guidelines - Week 1 Focus**
+
+As team captain, here are your key responsibilities to build team spirit:
+
+**🤝 Team Bonding (Days 1-3)**
+• Welcome each new member personally
+• Share your fitness goals and encourage others to do the same
+• Create a positive, supportive team culture
+
+**📋 Organization (Days 4-7)**
+• Help teammates understand league rules and scoring
+• Validate workout submissions promptly
+• Encourage consistent participation
+
+**💬 Communication Tips**
+• Check in with quiet team members
+• Celebrate small wins and progress
+• Address any concerns quickly and positively
+
+Your leadership sets the tone for the entire team's experience! 🌟`
+};
+
+// ============================================================================
+// Core Functions
+// ============================================================================
+
+/**
+ * Send automated welcome message when a new member joins a team
+ */
+export async function sendWelcomeMessage(
+    leagueId: string,
+    teamId: string,
+    newMemberUserId: string,
+    newMemberName: string
+): Promise<boolean> {
+    try {
+        const message = BONDING_TEMPLATES.welcome_new_member
+            .replace('{member_name}', newMemberName);
+
+        // Get the league host to send the message
+        const supabase = getSupabaseServiceRole();
+        const { data: league } = await supabase
+            .from('leagues')
+            .select('created_by')
+            .eq('league_id', leagueId)
+            .single();
+
+        if (!league?.created_by) {
+            console.error('[Bonding] No league host found');
+            return false;
+        }
+
+        const result = await sendMessage(leagueId, league.created_by, {
+            content: message,
+            teamId,
+            messageType: 'announcement',
+            visibility: 'all',
+            isImportant: false,
+        });
+
+        console.log(`[Bonding] Welcome message sent for ${newMemberName} in team ${teamId}`);
+        return !!result;
+    } catch (error) {
+        console.error('[Bonding] Error sending welcome message:', error);
+        return false;
+    }
+}
+
+/**
+ * Send team announcement when a new member is added
+ */
+export async function sendTeamAnnouncement(
+    leagueId: string,
+    teamId: string,
+    newMemberName: string
+): Promise<boolean> {
+    try {
+        // Get current team member count
+        const members = await getTeamMembers(teamId, leagueId);
+        const memberCount = members.length;
+
+        const message = BONDING_TEMPLATES.team_announcement
+            .replace('{member_name}', newMemberName)
+            .replace('{member_count}', memberCount.toString());
+
+        // Get the league host to send the message
+        const supabase = getSupabaseServiceRole();
+        const { data: league } = await supabase
+            .from('leagues')
+            .select('created_by')
+            .eq('league_id', leagueId)
+            .single();
+
+        if (!league?.created_by) {
+            console.error('[Bonding] No league host found');
+            return false;
+        }
+
+        const result = await sendMessage(leagueId, league.created_by, {
+            content: message,
+            teamId,
+            messageType: 'announcement',
+            visibility: 'all',
+            isImportant: false,
+        });
+
+        console.log(`[Bonding] Team announcement sent for ${newMemberName} in team ${teamId}`);
+        return !!result;
+    } catch (error) {
+        console.error('[Bonding] Error sending team announcement:', error);
+        return false;
+    }
+}
+
+/**
+ * Send team identity reveal message when league launches
+ */
+export async function sendTeamIdentityReveal(
+    leagueId: string,
+    teamId: string
+): Promise<boolean> {
+    try {
+        const supabase = getSupabaseServiceRole();
+
+        // Get team details
+        const { data: team } = await supabase
+            .from('teams')
+            .select('team_name, team_logo_url')
+            .eq('team_id', teamId)
+            .single();
+
+        if (!team) {
+            console.error('[Bonding] Team not found:', teamId);
+            return false;
+        }
+
+        // Get team members
+        const members = await getTeamMembers(teamId, leagueId);
+        const captain = members.find(m => m.is_captain);
+
+        // Build member list
+        const memberList = members
+            .map(m => `• ${m.username}${m.is_captain ? ' (Captain)' : ''}`)
+            .join('\n');
+
+        const message = BONDING_TEMPLATES.team_identity_reveal
+            .replace('{team_name}', team.team_name)
+            .replace('{member_list}', memberList)
+            .replace('{captain_name}', captain?.username || 'TBD');
+
+        // Get the league host to send the message
+        const { data: league } = await supabase
+            .from('leagues')
+            .select('created_by')
+            .eq('league_id', leagueId)
+            .single();
+
+        if (!league?.created_by) {
+            console.error('[Bonding] No league host found');
+            return false;
+        }
+
+        const result = await sendMessage(leagueId, league.created_by, {
+            content: message,
+            teamId,
+            messageType: 'announcement',
+            visibility: 'all',
+            isImportant: true,
+        });
+
+        console.log(`[Bonding] Team identity reveal sent for ${team.team_name}`);
+        return !!result;
+    } catch (error) {
+        console.error('[Bonding] Error sending team identity reveal:', error);
+        return false;
+    }
+}
+
+/**
+ * Send captain guidance message to newly assigned captains
+ */
+export async function sendCaptainGuidance(
+    leagueId: string,
+    teamId: string,
+    captainUserId: string
+): Promise<boolean> {
+    try {
+        const message = BONDING_TEMPLATES.captain_guidance;
+
+        // Get the league host to send the message
+        const supabase = getSupabaseServiceRole();
+        const { data: league } = await supabase
+            .from('leagues')
+            .select('created_by')
+            .eq('league_id', leagueId)
+            .single();
+
+        if (!league?.created_by) {
+            console.error('[Bonding] No league host found');
+            return false;
+        }
+
+        const result = await sendMessage(leagueId, league.created_by, {
+            content: message,
+            teamId,
+            messageType: 'announcement',
+            visibility: 'captains_only',
+            isImportant: true,
+        });
+
+        console.log(`[Bonding] Captain guidance sent to ${captainUserId} in team ${teamId}`);
+        return !!result;
+    } catch (error) {
+        console.error('[Bonding] Error sending captain guidance:', error);
+        return false;
+    }
+}
+
+/**
+ * Send team identity reveals for all teams when league launches
+ */
+export async function sendAllTeamIdentityReveals(leagueId: string): Promise<void> {
+    try {
+        const supabase = getSupabaseServiceRole();
+
+        // Get all teams in the league
+        const { data: teams } = await supabase
+            .from('teams')
+            .select('team_id')
+            .eq('league_id', leagueId);
+
+        if (!teams || teams.length === 0) {
+            console.log('[Bonding] No teams found for league:', leagueId);
+            return;
+        }
+
+        // Send identity reveal for each team
+        const promises = teams.map(team =>
+            sendTeamIdentityReveal(leagueId, team.team_id)
+        );
+
+        await Promise.all(promises);
+        console.log(`[Bonding] Team identity reveals sent for ${teams.length} teams`);
+    } catch (error) {
+        console.error('[Bonding] Error sending team identity reveals:', error);
+    }
+}
+
+/**
+ * Get captain guidelines content for in-app display
+ */
+export function getCaptainGuidelines(): string {
+    return BONDING_TEMPLATES.captain_guidance;
+}

--- a/src/lib/services/bonding-automations.ts
+++ b/src/lib/services/bonding-automations.ts
@@ -205,7 +205,7 @@ export async function sendTeamIdentityReveal(
             .join('\n');
 
         const message = BONDING_TEMPLATES.team_identity_reveal
-            .replace('{team_name}', team.team_name)
+            .replaceAll('{team_name}', team.team_name)
             .replace('{member_list}', memberList)
             .replace('{captain_name}', captain?.username || 'TBD');
 


### PR DESCRIPTION
## Summary

Rebase on latest develop, fix direct sonner import in `view-team-members-dialog.tsx`, and fix `{team_name}` only replacing first occurrence in identity reveal template.

## Related Issue

Closes #153

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] UI/UX improvement
- [ ] Chore (dependencies, config, CI)
- [ ] Documentation

## Changes Made

- Rebased on latest `origin/develop` (base commit `73f8886`)
- Fixed `view-team-members-dialog.tsx` line 37: `import { toast } from "sonner"` → `import { toast } from "@/lib/toast"`
- Fixed `bonding-automations.ts`: `.replace('{team_name}', ...)` → `.replaceAll('{team_name}', ...)` so both occurrences in the identity reveal template are substituted

## How to Test

1. Trigger identity reveal message on league launch — verify team name appears correctly in both places in the message
2. Run `pnpm lint` — verify no sonner direct import warning in `view-team-members-dialog.tsx`

## Checklist

- [x] I have tested this locally and it works
- [x] `pnpm build` passes with no errors
- [x] No `console.log` or commented-out code left behind
- [x] My branch is up to date with `develop`
- [x] I have not modified any files outside the scope of this task