### PR TITLE
fix: guided tour once per session + corporate as root landing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Toast scoping: informational toasts auto-dismiss after 4 seconds and all toasts clear on navigation (#151)
 - Fix `use-tournament-matches` and `submissions-table` importing toast directly from sonner, bypassing wrapper duration rules (#151)
 - Add inputMode="decimal" to distance input field for proper mobile keyboard (#133)
+- Guided tour only shows once per login session instead of on every navigation
+- Root URL `/` now serves the corporate landing page; old landing preserved at `/landing`
 
 ## [2.0.0] — 2026-04-01
 

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,2 @@
 /mfl-residential-wired.html /communities 301
-/mfl-landing-wired.html / 301
+/mfl-landing-wired.html /corporate 301

--- a/src/app/landing/page.tsx
+++ b/src/app/landing/page.tsx
@@ -1,0 +1,31 @@
+import {
+  LandingHeader,
+  HeroSection,
+  WhatIsSection,
+  PillarsSection,
+  HabitSection,
+  HowItWorksSection,
+  StoriesSection,
+  EveryoneSection,
+  CtaSection,
+  LandingFooter,
+} from '@/components/landing';
+
+export default function LandingPage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <LandingHeader />
+      <main>
+        <HeroSection />
+        <WhatIsSection />
+        <PillarsSection />
+        <HabitSection />
+        <HowItWorksSection />
+        <StoriesSection />
+        <EveryoneSection />
+        <CtaSection />
+      </main>
+      <LandingFooter />
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,31 +1,5 @@
-import {
-  LandingHeader,
-  HeroSection,
-  WhatIsSection,
-  PillarsSection,
-  HabitSection,
-  HowItWorksSection,
-  StoriesSection,
-  EveryoneSection,
-  CtaSection,
-  LandingFooter,
-} from '@/components/landing';
+import { redirect } from 'next/navigation';
 
-export default function LandingPage() {
-  return (
-    <div className="min-h-screen bg-background">
-      <LandingHeader />
-      <main>
-        <HeroSection />
-        <WhatIsSection />
-        <PillarsSection />
-        <HabitSection />
-        <HowItWorksSection />
-        <StoriesSection />
-        <EveryoneSection />
-        <CtaSection />
-      </main>
-      <LandingFooter />
-    </div>
-  );
+export default function RootPage() {
+  redirect('/corporate');
 }

--- a/src/components/onboarding/guided-tour.tsx
+++ b/src/components/onboarding/guided-tour.tsx
@@ -82,6 +82,7 @@ const FALLBACK_STEPS: TourStep[] = [
 ];
 
 const STORAGE_KEY = 'mfl_guided_tour_dismissed';
+const SESSION_KEY = 'mfl_tour_shown_this_session';
 
 // ---------------------------------------------------------------------------
 // Public API to re-open tour from Help menu
@@ -123,12 +124,17 @@ export function GuidedTour() {
       });
   }, []);
 
-  // Auto-open on first visit
+  // Auto-open once per session (unless permanently dismissed)
   useEffect(() => {
     try {
       const dismissed = localStorage.getItem(STORAGE_KEY);
       if (dismissed === 'true') return;
-      const timer = setTimeout(() => setOpen(true), 1500);
+      const shownThisSession = sessionStorage.getItem(SESSION_KEY);
+      if (shownThisSession === 'true') return;
+      const timer = setTimeout(() => {
+        setOpen(true);
+        sessionStorage.setItem(SESSION_KEY, 'true');
+      }, 1500);
       return () => clearTimeout(timer);
     } catch {}
   }, []);


### PR DESCRIPTION
## Summary
- **Guided tour** only auto-opens once per login session (sessionStorage flag), not on every navigation. Permanent "Don't show again" (localStorage) still works. Fixes client feedback from 15 Apr QA.
- **Root URL `/`** now redirects to `/corporate` (client request). Old React landing page preserved at `/landing`.
- Updated `_redirects` to prevent redirect loop.

## Related Issue
Client feedback from Ananth Sir (15 Apr QA review)

## Type of Change
- [x] Bug fix
- [ ] New feature

## How to Test
1. Login → navigate between pages → guided tour should only appear once, not on every My Activity visit
2. Visit `/` → should redirect to `/corporate` (the corporate landing page)
3. Visit `/landing` → should show the old React landing page
4. Visit `/corporate` → should still work as before

## Checklist
- [x] Tested locally
- [x] No console.log or commented-out code
- [x] Branch up to date with develop