### PR TITLE
feat: add login & signup buttons to corporate landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add inputMode="decimal" to distance input field for proper mobile keyboard (#133)
 - Guided tour only shows once per login session instead of on every navigation
 - Root URL `/` now serves the corporate landing page; old landing preserved at `/landing`
+- Add Log In and Sign Up buttons to corporate landing page nav bar
 
 ## [2.0.0] — 2026-04-01
 

--- a/public/mfl-landing-wired.html
+++ b/public/mfl-landing-wired.html
@@ -158,6 +158,26 @@
       background: var(--orange-dark);
     }
 
+    .nav-login {
+      color: var(--navy);
+      padding: .55rem 1.4rem;
+      font-family: 'DM Sans', sans-serif;
+      font-size: .82rem;
+      font-weight: 600;
+      cursor: pointer;
+      border-radius: 3px;
+      text-decoration: none;
+      transition: background .2s, color .2s;
+      white-space: nowrap;
+      border: 1.5px solid var(--navy);
+      background: transparent;
+    }
+
+    .nav-login:hover {
+      background: var(--navy);
+      color: #fff;
+    }
+
     /* ── CORP ID BANNER ── */
     .cid {
       background: var(--navy);
@@ -2090,6 +2110,11 @@
         white-space: nowrap;
       }
 
+      .nav-login {
+        font-size: .7rem;
+        padding: .45rem .85rem;
+      }
+
       .cid {
         padding: .65rem 1rem;
         margin-top: 50px;
@@ -2501,9 +2526,10 @@
         <span class="np on">🏢 Corporate</span>
         <a href="/communities" class="np">🏘️ Communities</a>
       </div>
+      <a href="/login" class="nav-login"
+        onclick="gtag('event', 'click', {'event_category': 'CTA', 'event_label': 'nav_login'});">Log In</a>
       <a href="/signup" class="nav-btn"
-        onclick="gtag('event', 'click', {'event_category': 'CTA', 'event_label': 'nav_cta'});">Launch Free — 7 Days
-        →</a>
+        onclick="gtag('event', 'click', {'event_category': 'CTA', 'event_label': 'nav_cta'});">Sign Up — Free →</a>
     </div>
   </nav>
 


### PR DESCRIPTION
## Summary
- Adds a **Log In** button (outline style) to the corporate landing page nav, linking to `/login`
- Renames the existing CTA from "Launch Free — 7 Days →" to **"Sign Up — Free →"** linking to `/signup`
- Both buttons include Google Analytics event tracking
- Responsive mobile styles included

## Changes
- `public/mfl-landing-wired.html`: Added `.nav-login` CSS class (outline button style with navy border, hover fill) + mobile responsive override + login anchor in nav
- `CHANGELOG.md`: Added entry under Fixed

## Test plan
- [ ] Visit `/corporate` — verify both "Log In" and "Sign Up — Free →" buttons appear in the nav bar
- [ ] Click "Log In" — should navigate to `/login`
- [ ] Click "Sign Up — Free →" — should navigate to `/signup`
- [ ] Test on mobile viewport — buttons should be sized appropriately
- [ ] Verify hover states (login: navy fill, signup: darker orange)