### PR TITLE
Feature: add suspicious-proof warning and 3-strike system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Captain intro prompt (nudge captain to introduce themselves) on league launch
   - First day of league motivational message to all teams (automated via cron)
   - Messages are configurable per league (host can enable/disable via bonding_automations_enabled)
+- Add suspicious-proof strike tracking system with warning UI and 3-strike logic (#157)
 
 ### Changed
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -36,7 +36,7 @@
 
 ### Database Migrations
 
-- No new database migrations required for v2.6 deliverables.
+- New migration for suspicious-proof strike tracking and related configuration
 
 ### Environment Setup
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 # Release Notes
 
 ## v2.6.0 - Client Readiness Release
+
 **Status:** On QA
 **Target:** v2.6 validation
 
@@ -16,7 +17,10 @@
 
 **Auto-Assignment Refinements** — Automatic rest day assignment now avoids days with existing submissions and respects updated rest day availability.
 
+**Fair Play Safeguards** — Suspicious submissions can now be flagged and tracked through a strike-based system, with warnings for players and improved visibility for captains and organizers.
+
 ### What's Fixed
+
 - Captain permissions and add-member edge cases
 - Chat workout attach flow and deep-link usability
 - Validation issues around duration, distance, and steps
@@ -27,17 +31,21 @@
 - Rest day donation sync, balance tracking, and auto-assignment inconsistencies.
 
 ### Breaking Changes
+
 - None.
 
 ### Database Migrations
+
 - No new database migrations required for v2.6 deliverables.
 
 ### Environment Setup
+
 - No new production environment variables required for v2.6 deliverables.
 
 ---
 
 ## v2.0.0 - Production-Ready Release
+
 **Released:** April 1, 2026
 
 ### Highlights
@@ -51,6 +59,7 @@
 **Challenge System Overhaul** - Removed the payment gate for challenges, fixed team scoring logic, and resolved sub-team all-or-nothing edge cases. Challenges are now more accessible and scores are accurate.
 
 ### What's Fixed
+
 - 26 bug fixes across leaderboards, rest day automation, submission handling, report accuracy, and UI polish. Major areas:
   - Auto rest day cron: timezone handling, late submissions, pre-start assignment
   - Leaderboard: deduplication, RR tiebreakers, truncation, decimal display
@@ -58,12 +67,14 @@
   - Security: cross-login session hardening
 
 ### Upgrade Notes
+
 - No database migrations required beyond v1.0.
 - No breaking API changes.
 
 ---
 
 ## v1.0.0 - Initial Release
+
 **Released:** February 11, 2026
 
 ### Highlights
@@ -81,6 +92,7 @@
 **Reports & Certificates** - Generate PDF league reports and downloadable certificates on league completion.
 
 ### Platform
+
 - **Frontend:** Next.js with TypeScript, Tailwind CSS, shadcn/ui
 - **Backend:** Supabase (PostgreSQL + Row-Level Security + Realtime)
 - **Auth:** NextAuth.js with Google OAuth and email/password
@@ -88,6 +100,7 @@
 - **Hosting:** Vercel
 
 ### Known Limitations
+
 - No team-level messaging (addressed in v2.5)
 - No AI-powered features (addressed in v2.5)
 - Single environment setup (multi-environment support added post-release)

--- a/src/app/(app)/leagues/[id]/submissions/page.tsx
+++ b/src/app/(app)/leagues/[id]/submissions/page.tsx
@@ -59,6 +59,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { Checkbox } from '@/components/ui/checkbox';
 import {
   Table,
   TableBody,
@@ -120,6 +121,7 @@ interface LeagueSubmission {
     email: string;
     team_id: string | null;
     team_name: string | null;
+    suspicious_proof_strikes?: number;
   };
 }
 
@@ -250,17 +252,19 @@ function RejectDialog({
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onConfirm: (type: 'rejected_resubmit' | 'rejected_permanent', reason: string) => void;
+  onConfirm: (type: 'rejected_resubmit' | 'rejected_permanent', reason: string, suspiciousProof: boolean) => void;
   isValidating: boolean;
 }) {
   const [reason, setReason] = useState('');
   const [type, setType] = useState<'rejected_resubmit' | 'rejected_permanent'>('rejected_resubmit');
+  const [suspiciousProof, setSuspiciousProof] = useState(false);
 
   // Reset state when dialog opens
   useEffect(() => {
     if (open) {
       setReason('');
       setType('rejected_resubmit');
+      setSuspiciousProof(false);
     }
   }, [open]);
 
@@ -327,6 +331,20 @@ function RejectDialog({
             />
           </div>
 
+          <div className="flex items-start gap-2 rounded-lg border border-muted p-4">
+            <Checkbox
+              checked={suspiciousProof}
+              onCheckedChange={(checked) => setSuspiciousProof(Boolean(checked))}
+              id="suspicious-proof"
+            />
+            <div>
+              <Label htmlFor="suspicious-proof">Flag as suspicious proof</Label>
+              <p className="text-sm text-muted-foreground">
+                If this proof looks fraudulent or inconsistent, mark it as suspicious. This will add a strike to the player's record and may escalate the next rejection.
+              </p>
+            </div>
+          </div>
+
           {type === 'rejected_permanent' && (
             <Alert variant="destructive">
               <AlertTriangle className="size-4" />
@@ -344,7 +362,7 @@ function RejectDialog({
           </Button>
           <Button
             variant={type === 'rejected_permanent' ? 'destructive' : 'default'}
-            onClick={() => onConfirm(type, reason)}
+            onClick={() => onConfirm(type, reason, suspiciousProof)}
             disabled={!reason.trim() || isValidating}
           >
             {isValidating && <Loader2 className="mr-2 size-4 animate-spin" />}
@@ -433,7 +451,8 @@ export default function AllSubmissionsPage({
     submissionId: string,
     newStatus: 'approved' | 'rejected_resubmit' | 'rejected_permanent',
     awardedPoints?: number | null,
-    rejectionReason?: string
+    rejectionReason?: string,
+    suspiciousProof?: boolean
   ) => {
     // Find the submission to get its current status
     const submission = submissions.find((s) => s.id === submissionId);
@@ -450,6 +469,7 @@ export default function AllSubmissionsPage({
       const body: any = { status: newStatus };
       if (awardedPoints !== undefined) body.awarded_points = awardedPoints;
       if (rejectionReason) body.rejection_reason = rejectionReason;
+      if (suspiciousProof !== undefined) body.suspicious_proof = suspiciousProof;
 
       const response = await fetch(`/api/submissions/${submissionId}/validate`, {
         method: 'POST',
@@ -983,6 +1003,11 @@ export default function AllSubmissionsPage({
                       <div className="min-w-0">
                         <p className="font-semibold text-sm leading-none truncate">{submission.member.username}</p>
                         <p className="text-xs text-muted-foreground">{submission.member.team_name || 'Unassigned'}</p>
+                        {submission.member.suspicious_proof_strikes ? (
+                          <Badge variant="outline" className="mt-1 text-[10px] px-2 py-1">
+                            {submission.member.suspicious_proof_strikes} strike{submission.member.suspicious_proof_strikes === 1 ? '' : 's'}
+                          </Badge>
+                        ) : null}
                       </div>
                     </div>
                     <div className="text-right shrink-0 ml-2">
@@ -1051,9 +1076,9 @@ export default function AllSubmissionsPage({
       <RejectDialog
         open={rejectDialogOpen}
         onOpenChange={setRejectDialogOpen}
-        onConfirm={(type, reason) => {
+        onConfirm={(type, reason, suspiciousProof) => {
           if (selectedSubmission) {
-            handleValidate(selectedSubmission.id, type, undefined, reason);
+            handleValidate(selectedSubmission.id, type, undefined, reason, suspiciousProof);
           }
         }}
         isValidating={!!validatingId}

--- a/src/app/(app)/leagues/[id]/submit/page.tsx
+++ b/src/app/(app)/leagues/[id]/submit/page.tsx
@@ -111,6 +111,9 @@ export default function SubmitActivityPage({
 
   // Fetch user profile for age calculation
   const [userAge, setUserAge] = React.useState<number | null>(null);
+  const [suspiciousProofStrikes, setSuspiciousProofStrikes] = React.useState<number>(0);
+  const [suspiciousProofWarningThreshold, setSuspiciousProofWarningThreshold] = React.useState<number>(2);
+  const [suspiciousProofRejectionThreshold, setSuspiciousProofRejectionThreshold] = React.useState<number>(3);
 
   React.useEffect(() => {
     async function fetchUserAge() {
@@ -130,6 +133,26 @@ export default function SubmitActivityPage({
     }
     fetchUserAge();
   }, []);
+
+  React.useEffect(() => {
+    const fetchStrikeCount = async () => {
+      if (!leagueId) return;
+
+      try {
+        const response = await fetch(`/api/leagues/${leagueId}/my-submissions`);
+        const json = await response.json();
+        if (response.ok && json.success) {
+          setSuspiciousProofStrikes(Number(json.data.suspiciousProofStrikes ?? 0));
+          setSuspiciousProofWarningThreshold(Number(json.data.suspiciousProofWarningThreshold ?? 2));
+          setSuspiciousProofRejectionThreshold(Number(json.data.suspiciousProofRejectionThreshold ?? 3));
+        }
+      } catch (error) {
+        console.error('Failed to fetch suspicious proof strikes:', error);
+      }
+    };
+
+    fetchStrikeCount();
+  }, [leagueId]);
 
   // Check if this is a resubmission
   const resubmitId = searchParams.get('resubmit');
@@ -1355,6 +1378,21 @@ export default function SubmitActivityPage({
 
       <TrialBanner />
 
+      {suspiciousProofStrikes >= suspiciousProofWarningThreshold && (
+        <Alert className="border-amber-200 bg-amber-50 dark:bg-amber-950/20">
+          <ShieldAlert className="size-4 text-amber-600" />
+          <AlertTitle className="text-amber-800 dark:text-amber-400">
+            Suspicious proof strike{suspiciousProofStrikes === 1 ? '' : 's'} on record
+          </AlertTitle>
+          <AlertDescription className="text-amber-700 dark:text-amber-300">
+            You currently have {suspiciousProofStrikes} suspicious proof strike{suspiciousProofStrikes === 1 ? '' : 's'}.
+            {suspiciousProofStrikes >= suspiciousProofRejectionThreshold - 1
+              ? ` One more suspicious-proof rejection can trigger permanent rejection at ${suspiciousProofRejectionThreshold} strikes.`
+              : ' Keep your proof clear and accurate to avoid escalation.'}
+          </AlertDescription>
+        </Alert>
+      )}
+
       {/* Team Assignment Required Check */}
       {activeLeague && !activeLeague.team_id && (
         <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 flex gap-3">
@@ -1374,15 +1412,15 @@ export default function SubmitActivityPage({
           <form onSubmit={handleSubmit} className="space-y-6">
             <div className="rounded-lg border bg-card/70 shadow-sm p-4 space-y-4 max-w-2xl">
               <TabsList className={`grid w-full ${showRestDays ? 'grid-cols-2' : 'grid-cols-1'}`}>
-                <TabsTrigger value="workout" className="flex items-center gap-2">
+                <TabsTrigger value="workout" className="flex items-center gap-2" disabled={Boolean(activeLeague && !activeLeague.team_id)}>
                   <Dumbbell className="size-4" />
                   Activity
                 </TabsTrigger>
                 {showRestDays && (
-                  <TabsTrigger value="rest" className="flex items-center gap-2">
-                    <Moon className="size-4" />
-                    Rest Day
-                  </TabsTrigger>
+                <TabsTrigger value="rest" className="flex items-center gap-2" disabled={Boolean(activeLeague && !activeLeague.team_id)}>
+                  <Moon className="size-4" />
+                  Rest Day
+                </TabsTrigger>
                 )}
               </TabsList>
 

--- a/src/app/api/leagues/[id]/my-submissions/route.ts
+++ b/src/app/api/leagues/[id]/my-submissions/route.ts
@@ -52,7 +52,7 @@ export async function GET(
     // Get the user's league_member_id for this league
     const { data: leagueMember, error: memberError } = await supabase
       .from('leaguemembers')
-      .select('league_member_id, team_id')
+      .select('league_member_id, team_id, suspicious_proof_strikes, suspicious_proof_last_strike_at')
       .eq('user_id', userId)
       .eq('league_id', leagueId)
       .maybeSingle();
@@ -71,6 +71,12 @@ export async function GET(
         { status: 403 }
       );
     }
+
+    const { data: leagueConfig } = await supabase
+      .from('leagues')
+      .select('suspicious_proof_warning_threshold, suspicious_proof_rejection_threshold')
+      .eq('league_id', leagueId)
+      .maybeSingle();
 
     // Get optional query params for filtering
     const { searchParams } = new URL(request.url);
@@ -212,6 +218,10 @@ export async function GET(
         stats,
         leagueMemberId: leagueMember.league_member_id,
         teamId: leagueMember.team_id,
+        suspiciousProofStrikes: leagueMember.suspicious_proof_strikes || 0,
+        suspiciousProofLastStrikeAt: leagueMember.suspicious_proof_last_strike_at || null,
+        suspiciousProofWarningThreshold: Number(leagueConfig?.suspicious_proof_warning_threshold ?? 2),
+        suspiciousProofRejectionThreshold: Number(leagueConfig?.suspicious_proof_rejection_threshold ?? 3),
       },
     });
   } catch (error) {

--- a/src/app/api/leagues/[id]/submissions/route.ts
+++ b/src/app/api/leagues/[id]/submissions/route.ts
@@ -83,6 +83,7 @@ export async function GET(
         league_member_id,
         user_id,
         team_id,
+        suspicious_proof_strikes,
         users!leaguemembers_user_id_fkey(username, email),
         teams(team_name)
       `)
@@ -114,6 +115,7 @@ export async function GET(
       email: string;
       team_id: string | null;
       team_name: string | null;
+      suspicious_proof_strikes: number;
     }>();
 
     const teamSet = new Set<string>();
@@ -127,6 +129,7 @@ export async function GET(
         email: user?.email || '',
         team_id: m.team_id,
         team_name: team?.team_name || null,
+        suspicious_proof_strikes: Number(m.suspicious_proof_strikes ?? 0),
       });
       if (m.team_id && team?.team_name) {
         teamSet.add(JSON.stringify({ team_id: m.team_id, team_name: team.team_name }));

--- a/src/app/api/submissions/[id]/validate/route.ts
+++ b/src/app/api/submissions/[id]/validate/route.ts
@@ -15,7 +15,12 @@ import { z } from 'zod';
 // ============================================================================
 
 const validateSchema = z.object({
-  status: z.enum(['approved', 'rejected', 'rejected_resubmit', 'rejected_permanent']),
+  status: z.enum([
+    'approved',
+    'rejected',
+    'rejected_resubmit',
+    'rejected_permanent',
+  ]),
   rejection_reason: z.string().optional(),
   awarded_points: z.number().optional(),
   suspicious_proof: z.boolean().optional(),
@@ -27,18 +32,21 @@ const validateSchema = z.object({
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try {
     const { id: submissionId } = await params;
-    const session = (await getServerSession(authOptions as any)) as import('next-auth').Session | null;
+    const session = (await getServerSession(authOptions as any)) as
+      | import('next-auth').Session
+      | null;
 
     if (!session?.user?.id) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     const body = await request.json();
-    let { status, rejection_reason, awarded_points, suspicious_proof } = validateSchema.parse(body);
+    let { status, rejection_reason, awarded_points, suspicious_proof } =
+      validateSchema.parse(body);
 
     // Map legacy 'rejected' to 'rejected_resubmit'
     if (status === 'rejected') {
@@ -51,7 +59,8 @@ export async function POST(
     // Get the submission with league info
     const { data: submission, error: submissionError } = await supabase
       .from('effortentry')
-      .select(`
+      .select(
+        `
         id,
         league_member_id,
         modified_by,
@@ -64,26 +73,33 @@ export async function POST(
           user_id,
           suspicious_proof_strikes
         )
-      `)
+      `,
+      )
       .eq('id', submissionId)
       .single();
 
     if (submissionError || !submission) {
       return NextResponse.json(
         { error: 'Submission not found' },
-        { status: 404 }
+        { status: 404 },
       );
     }
 
     const leagueMember = submission.leaguemembers as any;
     const leagueId = leagueMember.league_id;
     const submissionTeamId = leagueMember.team_id;
-    const currentStrikeCount = Number(leagueMember.suspicious_proof_strikes ?? 0);
+    const submissionLeagueMemberId = submission.league_member_id as string;
+    const currentStrikeCount = Number(
+      leagueMember.suspicious_proof_strikes ?? 0,
+    );
 
     let finalStatus = status;
     let shouldCountSuspiciousProof = false;
 
-    if (suspicious_proof && ['rejected_resubmit', 'rejected_permanent'].includes(status)) {
+    if (
+      suspicious_proof &&
+      ['rejected_resubmit', 'rejected_permanent'].includes(status)
+    ) {
       shouldCountSuspiciousProof = true;
       const { data: leagueRow, error: leagueFetchError } = await supabase
         .from('leagues')
@@ -91,11 +107,15 @@ export async function POST(
         .eq('league_id', leagueId)
         .single();
 
-      const escalationThreshold = !leagueFetchError && leagueRow?.suspicious_proof_rejection_threshold
-        ? Number(leagueRow.suspicious_proof_rejection_threshold)
-        : 3;
+      const escalationThreshold =
+        !leagueFetchError && leagueRow?.suspicious_proof_rejection_threshold
+          ? Number(leagueRow.suspicious_proof_rejection_threshold)
+          : 3;
 
-      if (currentStrikeCount + 1 >= escalationThreshold && status === 'rejected_resubmit') {
+      if (
+        currentStrikeCount + 1 >= escalationThreshold &&
+        status === 'rejected_resubmit'
+      ) {
         finalStatus = 'rejected_permanent';
       }
     }
@@ -104,7 +124,10 @@ export async function POST(
     // 1) Host/Governor override
     // NOTE: Do not use maybeSingle() for role checks: users often have multiple roles,
     // which causes maybeSingle() to fail and incorrectly deny permissions.
-    const canOverride = await userHasAnyRole(userId, leagueId, ['host', 'governor']);
+    const canOverride = await userHasAnyRole(userId, leagueId, [
+      'host',
+      'governor',
+    ]);
 
     // 3. Check if user is captain of the submission's team (via assignedrolesforleague)
     let isCaptainOfTeam = false;
@@ -154,15 +177,21 @@ export async function POST(
     if (!canOverride && !isCaptainOfTeam) {
       return NextResponse.json(
         { error: 'You do not have permission to validate this submission' },
-        { status: 403 }
+        { status: 403 },
       );
     }
 
     // Role-specific restrictions
-    if (status === 'rejected_permanent' && !canOverride) {
+    if (
+      (status === 'rejected_permanent' ||
+        finalStatus === 'rejected_permanent') &&
+      !canOverride
+    ) {
       return NextResponse.json(
-        { error: 'Only Hosts and Governors can permanently reject submissions' },
-        { status: 403 }
+        {
+          error: 'Only Hosts and Governors can permanently reject submissions',
+        },
+        { status: 403 },
       );
     }
 
@@ -174,7 +203,7 @@ export async function POST(
     if (!canOverride && !isCaptainOfTeam && leagueMember.user_id === userId) {
       return NextResponse.json(
         { error: 'You cannot validate your own submission' },
-        { status: 403 }
+        { status: 403 },
       );
     }
 
@@ -186,7 +215,10 @@ export async function POST(
     };
 
     // Store rejection reason if provided
-    if ((status === 'rejected_resubmit' || status === 'rejected_permanent') && rejection_reason) {
+    if (
+      (status === 'rejected_resubmit' || status === 'rejected_permanent') &&
+      rejection_reason
+    ) {
       updateData.rejection_reason = rejection_reason;
     }
 
@@ -205,22 +237,30 @@ export async function POST(
       console.error('Error updating submission:', updateError);
       return NextResponse.json(
         { error: 'Failed to update submission' },
-        { status: 500 }
+        { status: 500 },
       );
     }
 
     if (shouldCountSuspiciousProof) {
-      const newStrikeCount = currentStrikeCount + 1;
-      const { error: strikeUpdateError } = await supabase
-        .from('leaguemembers')
-        .update({
-          suspicious_proof_strikes: newStrikeCount,
-          suspicious_proof_last_strike_at: new Date().toISOString(),
-        })
-        .eq('league_member_id', leagueMember.league_member_id);
+      const { error: strikeUpdateError } = await supabase.rpc(
+        'increment_suspicious_proof_strike',
+        {
+          p_league_member_id: submissionLeagueMemberId,
+        },
+      );
 
       if (strikeUpdateError) {
-        console.error('Error updating suspicious proof strikes:', strikeUpdateError);
+        console.error(
+          'Error updating suspicious proof strikes:',
+          strikeUpdateError,
+        );
+        return NextResponse.json(
+          {
+            error:
+              'Submission was updated, but strike increment failed. Please retry or contact support.',
+          },
+          { status: 500 },
+        );
       }
     }
 
@@ -233,12 +273,12 @@ export async function POST(
     if (error instanceof z.ZodError) {
       return NextResponse.json(
         { error: 'Validation failed', details: error.errors },
-        { status: 400 }
+        { status: 400 },
       );
     }
     return NextResponse.json(
       { error: 'Failed to validate submission' },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/src/app/api/submissions/[id]/validate/route.ts
+++ b/src/app/api/submissions/[id]/validate/route.ts
@@ -18,6 +18,7 @@ const validateSchema = z.object({
   status: z.enum(['approved', 'rejected', 'rejected_resubmit', 'rejected_permanent']),
   rejection_reason: z.string().optional(),
   awarded_points: z.number().optional(),
+  suspicious_proof: z.boolean().optional(),
 });
 
 // ============================================================================
@@ -37,7 +38,7 @@ export async function POST(
     }
 
     const body = await request.json();
-    let { status, rejection_reason, awarded_points } = validateSchema.parse(body);
+    let { status, rejection_reason, awarded_points, suspicious_proof } = validateSchema.parse(body);
 
     // Map legacy 'rejected' to 'rejected_resubmit'
     if (status === 'rejected') {
@@ -60,7 +61,8 @@ export async function POST(
         leaguemembers!inner(
           league_id,
           team_id,
-          user_id
+          user_id,
+          suspicious_proof_strikes
         )
       `)
       .eq('id', submissionId)
@@ -76,6 +78,27 @@ export async function POST(
     const leagueMember = submission.leaguemembers as any;
     const leagueId = leagueMember.league_id;
     const submissionTeamId = leagueMember.team_id;
+    const currentStrikeCount = Number(leagueMember.suspicious_proof_strikes ?? 0);
+
+    let finalStatus = status;
+    let shouldCountSuspiciousProof = false;
+
+    if (suspicious_proof && ['rejected_resubmit', 'rejected_permanent'].includes(status)) {
+      shouldCountSuspiciousProof = true;
+      const { data: leagueRow, error: leagueFetchError } = await supabase
+        .from('leagues')
+        .select('suspicious_proof_rejection_threshold')
+        .eq('league_id', leagueId)
+        .single();
+
+      const escalationThreshold = !leagueFetchError && leagueRow?.suspicious_proof_rejection_threshold
+        ? Number(leagueRow.suspicious_proof_rejection_threshold)
+        : 3;
+
+      if (currentStrikeCount + 1 >= escalationThreshold && status === 'rejected_resubmit') {
+        finalStatus = 'rejected_permanent';
+      }
+    }
 
     // Check user's permissions to validate this submission
     // 1) Host/Governor override
@@ -157,13 +180,13 @@ export async function POST(
 
     // Update the submission status
     const updateData: Record<string, any> = {
-      status,
+      status: finalStatus,
       modified_by: userId,
       modified_date: new Date().toISOString(),
     };
 
     // Store rejection reason if provided
-    if ((status === 'rejected' || status === 'rejected_resubmit' || status === 'rejected_permanent') && rejection_reason) {
+    if ((status === 'rejected_resubmit' || status === 'rejected_permanent') && rejection_reason) {
       updateData.rejection_reason = rejection_reason;
     }
 
@@ -184,6 +207,21 @@ export async function POST(
         { error: 'Failed to update submission' },
         { status: 500 }
       );
+    }
+
+    if (shouldCountSuspiciousProof) {
+      const newStrikeCount = currentStrikeCount + 1;
+      const { error: strikeUpdateError } = await supabase
+        .from('leaguemembers')
+        .update({
+          suspicious_proof_strikes: newStrikeCount,
+          suspicious_proof_last_strike_at: new Date().toISOString(),
+        })
+        .eq('league_member_id', leagueMember.league_member_id);
+
+      if (strikeUpdateError) {
+        console.error('Error updating suspicious proof strikes:', strikeUpdateError);
+      }
     }
 
     return NextResponse.json({

--- a/src/hooks/use-my-submissions.ts
+++ b/src/hooks/use-my-submissions.ts
@@ -50,6 +50,10 @@ export interface MySubmissionsData {
   stats: SubmissionStats;
   leagueMemberId: string;
   teamId: string | null;
+  suspiciousProofStrikes: number;
+  suspiciousProofLastStrikeAt: string | null;
+  suspiciousProofWarningThreshold: number;
+  suspiciousProofRejectionThreshold: number;
 }
 
 export interface UseMySubmissionsReturn {

--- a/supabase/migrations/20260414_add_suspicious_proof_strikes.sql
+++ b/supabase/migrations/20260414_add_suspicious_proof_strikes.sql
@@ -1,0 +1,48 @@
+-- Suspicious-proof strike controls: strike count, last strike timestamp, and league thresholds
+
+ALTER TABLE public.leaguemembers
+  ADD COLUMN IF NOT EXISTS suspicious_proof_strikes integer DEFAULT 0 NOT NULL;
+
+ALTER TABLE public.leagues
+  ADD COLUMN IF NOT EXISTS suspicious_proof_warning_threshold integer DEFAULT 2 NOT NULL;
+
+ALTER TABLE public.leagues
+  ADD COLUMN IF NOT EXISTS suspicious_proof_rejection_threshold integer DEFAULT 3 NOT NULL;
+
+ALTER TABLE public.leaguemembers
+  ADD COLUMN IF NOT EXISTS suspicious_proof_last_strike_at timestamptz;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'leagues_suspicious_proof_warning_threshold_check'
+      AND conrelid = 'public.leagues'::regclass
+  ) THEN
+    ALTER TABLE public.leagues
+      ADD CONSTRAINT leagues_suspicious_proof_warning_threshold_check
+      CHECK (suspicious_proof_warning_threshold >= 1);
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'leagues_suspicious_proof_rejection_threshold_check'
+      AND conrelid = 'public.leagues'::regclass
+  ) THEN
+    ALTER TABLE public.leagues
+      ADD CONSTRAINT leagues_suspicious_proof_rejection_threshold_check
+      CHECK (
+        suspicious_proof_rejection_threshold >= suspicious_proof_warning_threshold
+      );
+  END IF;
+END $$;
+
+COMMENT ON COLUMN public.leaguemembers.suspicious_proof_strikes IS 'Number of suspicious-proof strikes for this member in this league';
+COMMENT ON COLUMN public.leaguemembers.suspicious_proof_last_strike_at IS 'Timestamp when the most recent suspicious-proof strike was issued';
+COMMENT ON COLUMN public.leagues.suspicious_proof_warning_threshold IS 'Strike count at or above which warning UX should be shown';
+COMMENT ON COLUMN public.leagues.suspicious_proof_rejection_threshold IS 'Strike count at or above which suspicious rejection escalates to permanent rejection';

--- a/supabase/migrations/20260414_add_suspicious_proof_strikes.sql
+++ b/supabase/migrations/20260414_add_suspicious_proof_strikes.sql
@@ -46,3 +46,31 @@ COMMENT ON COLUMN public.leaguemembers.suspicious_proof_strikes IS 'Number of su
 COMMENT ON COLUMN public.leaguemembers.suspicious_proof_last_strike_at IS 'Timestamp when the most recent suspicious-proof strike was issued';
 COMMENT ON COLUMN public.leagues.suspicious_proof_warning_threshold IS 'Strike count at or above which warning UX should be shown';
 COMMENT ON COLUMN public.leagues.suspicious_proof_rejection_threshold IS 'Strike count at or above which suspicious rejection escalates to permanent rejection';
+
+CREATE OR REPLACE FUNCTION public.increment_suspicious_proof_strike(
+  p_league_member_id uuid
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_new_strike_count integer;
+BEGIN
+  UPDATE public.leaguemembers
+  SET suspicious_proof_strikes = suspicious_proof_strikes + 1,
+      suspicious_proof_last_strike_at = now()
+  WHERE league_member_id = p_league_member_id
+  RETURNING suspicious_proof_strikes INTO v_new_strike_count;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'League member not found for strike increment: %', p_league_member_id;
+  END IF;
+
+  RETURN v_new_strike_count;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.increment_suspicious_proof_strike(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.increment_suspicious_proof_strike(uuid) TO service_role;


### PR DESCRIPTION
## Summary
Implements the anti-cheat suspicious-proof strike system, including strike tracking, warning UI, and integration with submission validation and review flow.


## Related Issue
Closes #157 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no functional change)
- [x] UI/UX improvement
- [ ] Chore (dependencies, config, CI)
- [ ] Documentation

## Changes Made
- Added suspicious-proof strike tracking per player per league
- Integrated suspicious_proof flag in submission validation flow
- Implemented strike increment logic for flagged rejected submissions
- Added warning banner UI for players based on strike count
- Added suspicious-proof checkbox in reject dialog for reviewers
- Exposed strike count in API responses
- Added DB migration for strike count, last strike timestamp, and league-level thresholds

## How to Test
1. Run the app locally (pnpm dev)
2. Navigate to submissions page as host/governor
3. Reject a submission and toggle "Flag as suspicious proof"
4. Verify request payload includes suspicious_proof
5. Confirm UI elements (checkbox, warning banner) render correctly
Note: Full end-to-end behavior (strike increment, thresholds, persistence) depends on the migration being applied.


## Checklist
- [x] I have tested this locally and it works
- [x] `pnpm build` passes with no errors
- [x] No `console.log` or commented-out code left behind
- [x] My branch is up to date with `develop`
- [x] I have not modified any files outside the scope of this task
