### PR TITLE
Fix: display readable labels for chat workout links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] — v2.6.0
 
 ### Added
+
 - Team messaging engine with realtime chat, @mentions, read receipts, and guided onboarding tour
 - AI Coach powered by Mistral: motivation nudges, captain insights, Q&A chatbot, and AI-assisted league creation wizard
 - AI League Manager: end-to-end AI-powered league setup and management
@@ -23,11 +24,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Messages use team collective language (not individual)
 
 ### Changed
+
 - Client feedback: filter dropdown, instant messaging UX, left-aligned dropdowns, mobile nav, league info title, and tour flow improvements
 - AI Coach v2.5: inline intelligence replaces standalone AI components
 - Disable submission actions and enforce read-only mode for ended leagues (#150)
 
 ### Fixed
+
 - Captain restricted to own team only; removed ability to switch between teams (#1)
 - Add-member API returns proper response for captain on own team instead of 403 (#2)
 - Chat attach workout: replaced auto-action with explicit popover menu (#3)
@@ -53,10 +56,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Log In and Sign Up buttons to corporate landing page nav bar
 - Fix rest day donation sync, availability, and donor balance logic (#152)
 - Fix auto-assignment inconsistencies and submission conflicts (#152)
+- Fix chat workout links to display readable labels (#132)
 
 ## [2.0.0] — 2026-04-01
 
 ### Added
+
 - League feedback banner on My Activity page
 - Admin dashboard: host info column and "Login as Host" impersonation button (#90, #91)
 - MyTeam stats: activity/challenge statistics cards, welcome message with first name (#89)
@@ -67,12 +72,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Date picker for workout submission date selection (#98)
 
 ### Changed
+
 - Text and CTA copy updates across the app (#84)
 - League home: removed search/pagination, added RR column, improved UX (#88)
 - Simplified team members view on individual leaderboard (#87)
 - Player/team count cards added to configure dialogs (#94)
 
 ### Fixed
+
 - Cron timezone handling for auto rest day, captain validation window, submit date (#85)
 - Leaderboard RR tiebreaker logic, team name editing (#86)
 - UI bugs, leaderboard deduplication, rest day count accuracy, league settings editability (#92)
@@ -93,6 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0] — 2026-02-11
 
 ### Added
+
 - **Core platform**: Next.js application with Supabase backend and NextAuth (Google + Credentials)
 - **League management**: Multi-step creation form with tier selection, pricing preview, Razorpay payment integration
 - **Role-based access**: Host, Governor, Captain, Player roles with permission-gated pages and role context
@@ -122,6 +130,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **SEO & branding**: Updated icons, manifest, metadata
 
 ### Changed
+
 - Renamed "Workout" to "Activity" across all UI surfaces
 - Renamed "Avg RR" to "RR" for consistency
 - Renamed "Challenge Bonus" to "Challenge Points"
@@ -130,6 +139,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced hardcoded colors with semantic CSS variables
 
 ### Fixed
+
 - Realtime leaderboard accumulation on league completion
 - Submission deadline extended to 9:00 AM UTC next day for league end day
 - Timezone handling with IANA support and `date-fns-tz` v3.2.0
@@ -140,6 +150,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Auto rest day league query filtering
 
 ### Infrastructure
+
 - Complete Supabase database schema (28 tables, enums, indexes)
 - Row-level security policies for all tables
 - Cron jobs: auto-approve old submissions, auto-assign rest days

--- a/src/components/messaging/message-bubble.tsx
+++ b/src/components/messaging/message-bubble.tsx
@@ -2,7 +2,16 @@
 
 import { useMemo, useState, type ReactNode } from 'react';
 import Link from 'next/link';
-import { Megaphone, ExternalLink, Pencil, Shield, Check, CheckCheck, Reply, SmilePlus } from 'lucide-react';
+import {
+  Megaphone,
+  ExternalLink,
+  Pencil,
+  Shield,
+  Check,
+  CheckCheck,
+  Reply,
+  SmilePlus,
+} from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
 
@@ -57,6 +66,12 @@ const ROLE_COLORS: Record<string, string> = {
 
 const QUICK_EMOJIS = ['👍', '❤️', '😂', '🎉', '💪', '🔥'];
 
+function containsUuid(value: string): boolean {
+  return /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i.test(
+    value,
+  );
+}
+
 function formatRelativeTime(dateStr: string): string {
   const date = new Date(dateStr);
   const now = new Date();
@@ -91,7 +106,7 @@ function deepLinkLabel(path: string): string {
   try {
     const url = new URL(path, 'https://mfl.local');
     const customLabel = url.searchParams.get('label');
-    if (customLabel) {
+    if (customLabel && !containsUuid(customLabel)) {
       return customLabel;
     }
   } catch {
@@ -118,7 +133,10 @@ function deepLinkLabel(path: string): string {
       validate: 'Validate',
       submissions: 'Submissions',
     };
-    return labels[section] || section.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+    return (
+      labels[section] ||
+      section.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+    );
   }
 
   // Fallback: return last meaningful segment, titlecased
@@ -131,7 +149,8 @@ function deepLinkLabel(path: string): string {
 function renderContent(content: string) {
   const parts: ReactNode[] = [];
   // Matches: **bold**, @[username](user_id) (legacy), @[username] (new), [text](url)
-  const regex = /(\*\*(.+?)\*\*)|(@\[([^\]]+)\](?:\([^)]+\))?)|(\[([^\]]+)\]\(([^)]+)\))/g;
+  const regex =
+    /(\*\*(.+?)\*\*)|(@\[([^\]]+)\](?:\([^)]+\))?)|(\[([^\]]+)\]\(([^)]+)\))/g;
   let lastIdx = 0;
   let match: RegExpExecArray | null;
 
@@ -144,7 +163,7 @@ function renderContent(content: string) {
       parts.push(
         <strong key={match.index} className="font-semibold">
           {match[2]}
-        </strong>
+        </strong>,
       );
     } else if (match[3]) {
       // @mention — @[username] or @[username](user_id)
@@ -154,7 +173,7 @@ function renderContent(content: string) {
           className="font-semibold text-blue-600 dark:text-blue-400 bg-blue-500/10 rounded px-0.5"
         >
           @{match[4]}
-        </span>
+        </span>,
       );
     } else if (match[5]) {
       // link — use in-app nav for internal paths, external for others
@@ -179,7 +198,7 @@ function renderContent(content: string) {
           >
             {match[6]}
           </a>
-        )
+        ),
       );
     }
     lastIdx = match.index + match[0].length;
@@ -202,11 +221,17 @@ interface MessageBubbleProps {
   onReact?: (messageId: string, emoji: string) => void;
 }
 
-export function MessageBubble({ message, isOwn, currentUserId, onReply, onReact }: MessageBubbleProps) {
+export function MessageBubble({
+  message,
+  isOwn,
+  currentUserId,
+  onReply,
+  onReact,
+}: MessageBubbleProps) {
   const [showEmojiPicker, setShowEmojiPicker] = useState(false);
   const relativeTime = useMemo(
     () => formatRelativeTime(message.created_at),
-    [message.created_at]
+    [message.created_at],
   );
 
   const isAnnouncement = message.message_type === 'announcement';
@@ -228,7 +253,7 @@ export function MessageBubble({ message, isOwn, currentUserId, onReply, onReact 
     <div
       className={cn(
         'group flex flex-col max-w-[85%] sm:max-w-[70%]',
-        isOwn ? 'self-end items-end' : 'self-start items-start'
+        isOwn ? 'self-end items-end' : 'self-start items-start',
       )}
     >
       {/* Single self-contained bubble — WhatsApp style */}
@@ -239,24 +264,28 @@ export function MessageBubble({ message, isOwn, currentUserId, onReply, onReact 
             ? 'bg-amber-50 dark:bg-amber-950/40 border border-amber-300 dark:border-amber-700 text-foreground'
             : isOwn
               ? 'bg-primary text-primary-foreground rounded-br-md'
-              : 'bg-muted text-foreground rounded-bl-md'
+              : 'bg-muted text-foreground rounded-bl-md',
         )}
         style={{ overflowWrap: 'anywhere' }}
       >
         {/* Sender name + role badge — inside bubble */}
         {!isOwn && (
           <div className="flex items-center gap-1.5 mb-1">
-            <span className={cn(
-              'text-xs font-semibold',
-              isAnnouncement ? 'text-amber-800 dark:text-amber-300' : 'text-blue-600 dark:text-blue-400'
-            )}>
+            <span
+              className={cn(
+                'text-xs font-semibold',
+                isAnnouncement
+                  ? 'text-amber-800 dark:text-amber-300'
+                  : 'text-blue-600 dark:text-blue-400',
+              )}
+            >
               {message.sender_name || message.sender_username || 'Unknown'}
             </span>
             <Badge
               variant="outline"
               className={cn(
                 'text-[10px] px-1.5 py-0 h-4 capitalize',
-                ROLE_COLORS[message.sender_role] ?? ROLE_COLORS.player
+                ROLE_COLORS[message.sender_role] ?? ROLE_COLORS.player,
               )}
             >
               {message.sender_role}
@@ -285,22 +314,30 @@ export function MessageBubble({ message, isOwn, currentUserId, onReply, onReact 
 
         {/* Reply preview — quoted parent message */}
         {message.parent_message && (
-          <div className={cn(
-            'rounded-lg px-2.5 py-1.5 mb-1.5 border-l-2',
-            isOwn
-              ? 'bg-primary-foreground/10 border-primary-foreground/40'
-              : 'bg-background/50 border-blue-400'
-          )}>
-            <span className={cn(
-              'text-[11px] font-semibold block',
-              isOwn ? 'text-primary-foreground/80' : 'text-blue-600 dark:text-blue-400'
-            )}>
+          <div
+            className={cn(
+              'rounded-lg px-2.5 py-1.5 mb-1.5 border-l-2',
+              isOwn
+                ? 'bg-primary-foreground/10 border-primary-foreground/40'
+                : 'bg-background/50 border-blue-400',
+            )}
+          >
+            <span
+              className={cn(
+                'text-[11px] font-semibold block',
+                isOwn
+                  ? 'text-primary-foreground/80'
+                  : 'text-blue-600 dark:text-blue-400',
+              )}
+            >
               {message.parent_message.sender_username}
             </span>
-            <span className={cn(
-              'text-[11px] line-clamp-2',
-              isOwn ? 'text-primary-foreground/60' : 'text-muted-foreground'
-            )}>
+            <span
+              className={cn(
+                'text-[11px] line-clamp-2',
+                isOwn ? 'text-primary-foreground/60' : 'text-muted-foreground',
+              )}
+            >
               {message.parent_message.content}
             </span>
           </div>
@@ -315,7 +352,7 @@ export function MessageBubble({ message, isOwn, currentUserId, onReply, onReact 
             href={message.deep_link}
             className={cn(
               'mt-2 flex items-center gap-2 rounded-lg border px-3 py-2 text-xs transition-colors',
-              'bg-background/50 hover:bg-background/80 border-border text-foreground'
+              'bg-background/50 hover:bg-background/80 border-border text-foreground',
             )}
           >
             <ExternalLink className="size-3.5 shrink-0" />
@@ -324,10 +361,12 @@ export function MessageBubble({ message, isOwn, currentUserId, onReply, onReact 
         )}
 
         {/* Meta row — timestamp, edited, visibility, read receipt — all inside bubble */}
-        <div className={cn(
-          'flex items-center gap-1.5 mt-1 justify-end',
-          isOwn ? 'text-primary-foreground/60' : 'text-muted-foreground'
-        )}>
+        <div
+          className={cn(
+            'flex items-center gap-1.5 mt-1 justify-end',
+            isOwn ? 'text-primary-foreground/60' : 'text-muted-foreground',
+          )}
+        >
           {message.visibility === 'captains_only' && (
             <span className="flex items-center gap-0.5 text-[10px] text-purple-600 dark:text-purple-400">
               <Shield className="size-2.5" />
@@ -341,18 +380,21 @@ export function MessageBubble({ message, isOwn, currentUserId, onReply, onReact 
             </span>
           )}
           <span className="text-[10px]">{relativeTime}</span>
-          {isOwn && (
-            message.is_read
-              ? <CheckCheck className="size-3 text-blue-400" />
-              : <Check className="size-3" />
-          )}
+          {isOwn &&
+            (message.is_read ? (
+              <CheckCheck className="size-3 text-blue-400" />
+            ) : (
+              <Check className="size-3" />
+            ))}
         </div>
 
         {/* Hover actions — reply & react */}
-        <div className={cn(
-          'absolute -top-3 opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-0.5 bg-background border rounded-lg shadow-sm px-1 py-0.5',
-          isOwn ? 'left-0' : 'right-0'
-        )}>
+        <div
+          className={cn(
+            'absolute -top-3 opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-0.5 bg-background border rounded-lg shadow-sm px-1 py-0.5',
+            isOwn ? 'left-0' : 'right-0',
+          )}
+        >
           {onReply && (
             <button
               type="button"
@@ -377,10 +419,12 @@ export function MessageBubble({ message, isOwn, currentUserId, onReply, onReact 
 
         {/* Quick emoji picker */}
         {showEmojiPicker && onReact && (
-          <div className={cn(
-            'absolute -top-10 z-10 flex items-center gap-0.5 bg-background border rounded-xl shadow-lg px-2 py-1',
-            isOwn ? 'left-0' : 'right-0'
-          )}>
+          <div
+            className={cn(
+              'absolute -top-10 z-10 flex items-center gap-0.5 bg-background border rounded-xl shadow-lg px-2 py-1',
+              isOwn ? 'left-0' : 'right-0',
+            )}
+          >
             {QUICK_EMOJIS.map((emoji) => (
               <button
                 key={emoji}
@@ -400,12 +444,16 @@ export function MessageBubble({ message, isOwn, currentUserId, onReply, onReact 
 
       {/* Reactions row — below the bubble */}
       {reactions.length > 0 && (
-        <div className={cn(
-          'flex flex-wrap gap-1 mt-0.5 px-1',
-          isOwn ? 'justify-end' : 'justify-start'
-        )}>
+        <div
+          className={cn(
+            'flex flex-wrap gap-1 mt-0.5 px-1',
+            isOwn ? 'justify-end' : 'justify-start',
+          )}
+        >
           {reactions.map((r) => {
-            const hasReacted = currentUserId ? r.user_ids.includes(currentUserId) : false;
+            const hasReacted = currentUserId
+              ? r.user_ids.includes(currentUserId)
+              : false;
             return (
               <button
                 key={r.emoji}
@@ -415,11 +463,13 @@ export function MessageBubble({ message, isOwn, currentUserId, onReply, onReact 
                   'inline-flex items-center gap-0.5 rounded-full border px-1.5 py-0.5 text-xs transition-colors',
                   hasReacted
                     ? 'bg-primary/10 border-primary/30 text-primary'
-                    : 'bg-muted/50 border-border text-muted-foreground hover:bg-muted'
+                    : 'bg-muted/50 border-border text-muted-foreground hover:bg-muted',
                 )}
               >
                 <span>{r.emoji}</span>
-                <span className="text-[10px] font-medium">{r.user_ids.length}</span>
+                <span className="text-[10px] font-medium">
+                  {r.user_ids.length}
+                </span>
               </button>
             );
           })}

--- a/src/components/messaging/message-input.tsx
+++ b/src/components/messaging/message-input.tsx
@@ -45,6 +45,24 @@ interface RecentWorkout {
   custom_activity_name?: string | null;
 }
 
+function isUuidLike(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+    value,
+  );
+}
+
+function formatWorkoutTypeLabel(type: string | null): string {
+  if (!type || isUuidLike(type)) return 'Workout';
+  return type
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+function toPossessive(name: string): string {
+  return name.endsWith('s') ? `${name}'` : `${name}'s`;
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -89,8 +107,7 @@ export function MessageInput({
   const [mentionQuery, setMentionQuery] = useState('');
   const [mentionStartIdx, setMentionStartIdx] = useState(-1);
 
-  const isHostOrGovernor =
-    currentRole === 'host' || currentRole === 'governor';
+  const isHostOrGovernor = currentRole === 'host' || currentRole === 'governor';
   // All roles can toggle captains_only (players use it as DM to captain)
   const canSetVisibility = true;
   const canMarkImportant = isHostOrGovernor;
@@ -176,7 +193,7 @@ export function MessageInput({
     // Replace @query with @[username]
     const before = content.slice(0, mentionStartIdx);
     const after = content.slice(
-      mentionStartIdx + 1 + mentionQuery.length // +1 for '@'
+      mentionStartIdx + 1 + mentionQuery.length, // +1 for '@'
     );
     const mention = `@[${member.username}] `;
     const newContent = before + mention + after;
@@ -222,7 +239,13 @@ export function MessageInput({
         is_read: true,
         deep_link: deepLink || null,
         parent_message_id: replyTo?.message_id || null,
-        parent_message: replyTo ? { sender_username: replyTo.sender_username || replyTo.sender_name || '', content: replyTo.content } : null,
+        parent_message: replyTo
+          ? {
+              sender_username:
+                replyTo.sender_username || replyTo.sender_name || '',
+              content: replyTo.content,
+            }
+          : null,
         created_at: new Date().toISOString(),
         edited_at: null,
         sender_role: currentRole || 'player',
@@ -261,12 +284,23 @@ export function MessageInput({
       textareaRef.current?.focus();
     } catch (err) {
       toast.error(
-        err instanceof Error ? err.message : 'Failed to send message'
+        err instanceof Error ? err.message : 'Failed to send message',
       );
     } finally {
       setSending(false);
     }
-  }, [content, sending, visibility, isImportant, isAnnouncement, deepLink, teamId, leagueId, replyTo, onMessageSent]);
+  }, [
+    content,
+    sending,
+    visibility,
+    isImportant,
+    isAnnouncement,
+    deepLink,
+    teamId,
+    leagueId,
+    replyTo,
+    onMessageSent,
+  ]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     // If mention dropdown is visible, let it handle Enter/Tab/Arrow keys
@@ -288,13 +322,17 @@ export function MessageInput({
   };
 
   const handleWorkoutSelect = (workout: RecentWorkout) => {
-    const workoutLabel = workout.custom_activity_name || (workout.workout_type
-      ? workout.workout_type
-        .split('_')
-        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-        .join(' ')
-      : 'Workout');
-    const label = `${workoutLabel} • ${format(parseISO(workout.date), 'MMM d')}`;
+    const baseWorkoutLabel =
+      workout.custom_activity_name ||
+      formatWorkoutTypeLabel(workout.workout_type);
+    const workoutLabel = /session$/i.test(baseWorkoutLabel)
+      ? baseWorkoutLabel
+      : `${baseWorkoutLabel} Session`;
+    const senderFirstName = session?.user?.name?.trim().split(/\s+/)[0];
+    const senderPrefix = senderFirstName
+      ? `${toPossessive(senderFirstName)} `
+      : '';
+    const label = `${senderPrefix}${workoutLabel} - ${format(parseISO(workout.date), 'MMM d')}`;
     const params = new URLSearchParams({
       submissionId: workout.id,
       label,
@@ -381,16 +419,25 @@ export function MessageInput({
                 size="sm"
                 className={cn(
                   'h-8 shrink-0 gap-1 text-xs',
-                  (isAnnouncement || isImportant || visibility === 'captains_only') &&
-                  'border-amber-400 text-amber-600 dark:text-amber-400'
+                  (isAnnouncement ||
+                    isImportant ||
+                    visibility === 'captains_only') &&
+                    'border-amber-400 text-amber-600 dark:text-amber-400',
                 )}
               >
                 {isAnnouncement ? (
-                  <><Megaphone className="size-3" /> Announcement</>
+                  <>
+                    <Megaphone className="size-3" /> Announcement
+                  </>
                 ) : visibility === 'captains_only' ? (
-                  <><Shield className="size-3" /> {currentRole === 'player' ? 'DM Captain' : 'Captains'}</>
+                  <>
+                    <Shield className="size-3" />{' '}
+                    {currentRole === 'player' ? 'DM Captain' : 'Captains'}
+                  </>
                 ) : (
-                  <><Globe className="size-3" /> All</>
+                  <>
+                    <Globe className="size-3" /> All
+                  </>
                 )}
                 <ChevronDown className="size-3" />
               </Button>
@@ -416,10 +463,14 @@ export function MessageInput({
                   </DropdownMenuItem>
                   <DropdownMenuItem
                     onClick={() => setVisibility('captains_only')}
-                    className={cn(visibility === 'captains_only' && 'bg-accent')}
+                    className={cn(
+                      visibility === 'captains_only' && 'bg-accent',
+                    )}
                   >
                     <Shield className="size-4 mr-2" />
-                    {currentRole === 'player' ? 'DM to Captain' : 'Captains Only'}
+                    {currentRole === 'player'
+                      ? 'DM to Captain'
+                      : 'Captains Only'}
                   </DropdownMenuItem>
                 </>
               )}
@@ -438,7 +489,10 @@ export function MessageInput({
 
         {/* Canned messages */}
         {canSetVisibility && (
-          <CannedMessagePicker leagueId={leagueId} onSelect={handleCannedSelect} />
+          <CannedMessagePicker
+            leagueId={leagueId}
+            onSelect={handleCannedSelect}
+          />
         )}
 
         {/* AI Motivate Team — captain only */}
@@ -452,7 +506,11 @@ export function MessageInput({
             onClick={handleMotivateTeam}
             title="AI-generated team motivation message"
           >
-            {motivating ? <Loader2 className="size-3.5 animate-spin" /> : <Zap className="size-3.5" />}
+            {motivating ? (
+              <Loader2 className="size-3.5 animate-spin" />
+            ) : (
+              <Zap className="size-3.5" />
+            )}
             <span className="hidden sm:inline">Motivate</span>
           </Button>
         )}
@@ -464,14 +522,19 @@ export function MessageInput({
               type="button"
               variant="ghost"
               size="icon"
-              className={cn('size-8 shrink-0', deepLink && 'text-green-600 dark:text-green-400')}
+              className={cn(
+                'size-8 shrink-0',
+                deepLink && 'text-green-600 dark:text-green-400',
+              )}
               title="Attach a workout"
             >
               <Dumbbell className="size-4" />
             </Button>
           </PopoverTrigger>
           <PopoverContent align="start" side="top" className="w-56 p-1">
-            <p className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">Attach a workout</p>
+            <p className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">
+              Attach a workout
+            </p>
             {deepLink && (
               <button
                 type="button"
@@ -482,14 +545,21 @@ export function MessageInput({
                 Remove attached link
               </button>
             )}
-            <RecentWorkoutPicker leagueId={leagueId} onSelect={handleWorkoutSelect} />
+            <RecentWorkoutPicker
+              leagueId={leagueId}
+              onSelect={handleWorkoutSelect}
+            />
             <button
               type="button"
               className={cn(
                 'w-full flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent',
-                deepLink === `/leagues/${leagueId}/challenges` && 'bg-accent font-medium'
+                deepLink === `/leagues/${leagueId}/challenges` &&
+                  'bg-accent font-medium',
               )}
-              onClick={() => { setDeepLink(`/leagues/${leagueId}/challenges`); setAttachMenuOpen(false); }}
+              onClick={() => {
+                setDeepLink(`/leagues/${leagueId}/challenges`);
+                setAttachMenuOpen(false);
+              }}
             >
               <Link2 className="size-3.5" />
               Challenges
@@ -498,9 +568,13 @@ export function MessageInput({
               type="button"
               className={cn(
                 'w-full flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent',
-                deepLink === `/leagues/${leagueId}/leaderboard` && 'bg-accent font-medium'
+                deepLink === `/leagues/${leagueId}/leaderboard` &&
+                  'bg-accent font-medium',
               )}
-              onClick={() => { setDeepLink(`/leagues/${leagueId}/leaderboard`); setAttachMenuOpen(false); }}
+              onClick={() => {
+                setDeepLink(`/leagues/${leagueId}/leaderboard`);
+                setAttachMenuOpen(false);
+              }}
             >
               <Link2 className="size-3.5" />
               Leaderboard
@@ -509,9 +583,13 @@ export function MessageInput({
               type="button"
               className={cn(
                 'w-full flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent',
-                deepLink === `/leagues/${leagueId}/activities` && 'bg-accent font-medium'
+                deepLink === `/leagues/${leagueId}/activities` &&
+                  'bg-accent font-medium',
               )}
-              onClick={() => { setDeepLink(`/leagues/${leagueId}/activities`); setAttachMenuOpen(false); }}
+              onClick={() => {
+                setDeepLink(`/leagues/${leagueId}/activities`);
+                setAttachMenuOpen(false);
+              }}
             >
               <Link2 className="size-3.5" />
               Activities


### PR DESCRIPTION
## Summary
Fixes workout links in team chat showing raw UUIDs by displaying human-readable labels while preserving correct navigation.


## Related Issue
Closes #132 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [x] UI/UX improvement
- [ ] Chore (dependencies, config, CI)
- [ ] Documentation

## Changes Made
- Replaced visible UUIDs in chat workout links with human-readable labels
- Ensured deep link href still contains UUID for correct routing
- Added safer label generation in message creation logic
- Added render-time fallback to prevent UUID exposure in message bubbles

## How to Test
1. Run the app locally (pnpm dev)
2. Open team chat
3. Share a workout link
4. Verify the message shows a readable label (not UUID)
5. Click the link and confirm it navigates correctly

## Screenshots / Recordings
<img width="1919" height="865" alt="Screenshot 2026-04-21 131122" src="https://github.com/user-attachments/assets/fd8d5d15-af3f-4f04-bf72-ac06e45eaa3b" />


## Checklist
- [x] I have tested this locally and it works
- [x] `pnpm build` passes with no errors
- [x] No `console.log` or commented-out code left behind
- [x] My branch is up to date with `develop`
- [x] I have not modified any files outside the scope of this task
