### PR TITLE
Feature/154 auto trigger bonding messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Captain Guidelines document/tooltip accessible in-app with Week 1 focus
   - System-generated team identity reveal message (team name + logo) on league launch
   - Messages use team collective language (not individual)
+- **Auto-trigger pre-launch bonding messages at key lifecycle moments (#154)**
+  - Team reveal celebration message when league launches
+  - Captain intro prompt (nudge captain to introduce themselves) on league launch
+  - First day of league motivational message to all teams (automated via cron)
+  - Messages are configurable per league (host can enable/disable via bonding_automations_enabled)
 
 ### Changed
 - Client feedback: filter dropdown, instant messaging UX, left-aligned dropdowns, mobile nav, league info title, and tour flow improvements

--- a/src/app/api/cron/first-day-motivation/route.ts
+++ b/src/app/api/cron/first-day-motivation/route.ts
@@ -1,0 +1,99 @@
+/**
+ * GET /api/cron/first-day-motivation - Send first day motivation messages
+ * 
+ * This cron job runs ONCE PER DAY at 00:00 UTC and sends motivational messages
+ * to all teams in leagues that are starting today (start_date = today).
+ * 
+ * Security: Validates CRON_SECRET header from Vercel
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseServiceRole } from '@/lib/supabase/client';
+import { sendFirstDayMotivation } from '@/lib/services/bonding-automations';
+
+const LOG_PREFIX = '[CRON][first-day-motivation]';
+
+function logCron(message: string, extra?: Record<string, unknown>) {
+    if (extra && Object.keys(extra).length > 0) {
+        console.log(LOG_PREFIX, message, extra);
+    } else {
+        console.log(LOG_PREFIX, message);
+    }
+}
+
+export async function GET(req: NextRequest) {
+    try {
+        const startTs = new Date().toISOString();
+        logCron('START', { at: startTs });
+
+        // Verify cron secret
+        const authHeader = req.headers.get('authorization');
+        const cronSecret = process.env.CRON_SECRET;
+
+        if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+            console.warn('Unauthorized first-day-motivation cron attempt');
+            return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+        }
+
+        const supabase = getSupabaseServiceRole();
+        const today = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
+
+        // Get leagues starting today with bonding automations enabled
+        const { data: leagues, error: leaguesError } = await supabase
+            .from('leagues')
+            .select('league_id, league_name')
+            .eq('start_date', today)
+            .eq('bonding_automations_enabled', true)
+            .eq('is_active', true)
+            .in('status', ['active', 'scheduled', 'launched']);
+
+        if (leaguesError) {
+            console.error('Error fetching leagues starting today:', leaguesError);
+            return NextResponse.json(
+                { error: 'Failed to fetch leagues' },
+                { status: 500 }
+            );
+        }
+
+        if (!leagues || leagues.length === 0) {
+            logCron('NO_LEAGUES_STARTING', { date: today });
+            return NextResponse.json({
+                success: true,
+                message: 'No leagues starting today',
+                sent: 0,
+            });
+        }
+
+        logCron('LEAGUES_FOUND', { count: leagues.length, date: today });
+
+        // Send first day motivation for each league
+        let successCount = 0;
+        for (const league of leagues) {
+            try {
+                await sendFirstDayMotivation(league.league_id);
+                successCount++;
+                logCron('SENT', { league: league.league_id, name: league.league_name });
+            } catch (error) {
+                console.error(`Failed to send first day motivation for league ${league.league_id}:`, error);
+            }
+        }
+
+        logCron('END', {
+            total: leagues.length,
+            sent: successCount,
+            duration_ms: Date.now() - new Date(startTs).getTime(),
+        });
+
+        return NextResponse.json({
+            success: true,
+            message: `Sent first day motivation to ${successCount} leagues`,
+            sent: successCount,
+            total: leagues.length,
+        });
+    } catch (error) {
+        console.error('Error in first-day-motivation cron:', error);
+        return NextResponse.json(
+            { error: 'Internal server error' },
+            { status: 500 }
+        );
+    }
+}

--- a/src/app/api/leagues/[id]/launch/route.ts
+++ b/src/app/api/leagues/[id]/launch/route.ts
@@ -5,7 +5,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/lib/auth/config';
 import { launchLeague } from '@/lib/services/leagues';
-import { sendAllTeamIdentityReveals, sendCaptainIntroPrompts } from '@/lib/services/bonding-automations';
+import { sendLaunchBondingMessages } from '@/lib/services/bonding-automations';
 
 export async function POST(
   request: NextRequest,
@@ -28,14 +28,9 @@ export async function POST(
       );
     }
 
-    // Send team identity reveals for all teams (don't block response)
-    sendAllTeamIdentityReveals(id).catch(error => {
-      console.error('[Bonding] Error sending team identity reveals:', error);
-    });
-
-    // Send captain intro prompts (don't block response)
-    sendCaptainIntroPrompts(id).catch(error => {
-      console.error('[Bonding] Error sending captain intro prompts:', error);
+    // Send launch bonding messages (team reveals + captain prompts) - optimized with consolidated queries
+    sendLaunchBondingMessages(id).catch(error => {
+      console.error('[Bonding] Error sending launch bonding messages:', error);
     });
 
     return NextResponse.json({ data: league, success: true });

--- a/src/app/api/leagues/[id]/launch/route.ts
+++ b/src/app/api/leagues/[id]/launch/route.ts
@@ -5,7 +5,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/lib/auth/config';
 import { launchLeague } from '@/lib/services/leagues';
-import { sendAllTeamIdentityReveals } from '@/lib/services/bonding-automations';
+import { sendAllTeamIdentityReveals, sendCaptainIntroPrompts } from '@/lib/services/bonding-automations';
 
 export async function POST(
   request: NextRequest,
@@ -31,6 +31,11 @@ export async function POST(
     // Send team identity reveals for all teams (don't block response)
     sendAllTeamIdentityReveals(id).catch(error => {
       console.error('[Bonding] Error sending team identity reveals:', error);
+    });
+
+    // Send captain intro prompts (don't block response)
+    sendCaptainIntroPrompts(id).catch(error => {
+      console.error('[Bonding] Error sending captain intro prompts:', error);
     });
 
     return NextResponse.json({ data: league, success: true });

--- a/src/lib/services/bonding-automations.ts
+++ b/src/lib/services/bonding-automations.ts
@@ -384,13 +384,28 @@ export async function sendCaptainIntroPrompts(leagueId: string): Promise<void> {
             return;
         }
 
+        // Filter teams that have captains assigned
+        const teamsWithCaptains = [];
+        for (const team of teams) {
+            const members = await getTeamMembers(team.team_id, leagueId);
+            const hasCaptain = members.some(m => m.is_captain);
+            if (hasCaptain) {
+                teamsWithCaptains.push(team.team_id);
+            }
+        }
+
+        if (teamsWithCaptains.length === 0) {
+            console.log('[Bonding] No teams with captains found for league:', leagueId);
+            return;
+        }
+
         const message = BONDING_TEMPLATES.captain_intro_prompt;
 
-        // Send intro prompt to each team (captains will see it)
-        const promises = teams.map(team =>
+        // Send intro prompt only to teams with captains
+        const promises = teamsWithCaptains.map(teamId =>
             sendMessage(leagueId, league.created_by, {
                 content: message,
-                teamId: team.team_id,
+                teamId: teamId,
                 messageType: 'announcement',
                 visibility: 'captains_only',
                 isImportant: true,
@@ -398,7 +413,7 @@ export async function sendCaptainIntroPrompts(leagueId: string): Promise<void> {
         );
 
         await Promise.all(promises);
-        console.log(`[Bonding] Captain intro prompts sent for ${teams.length} teams`);
+        console.log(`[Bonding] Captain intro prompts sent for ${teamsWithCaptains.length} teams with captains`);
     } catch (error) {
         console.error('[Bonding] Error sending captain intro prompts:', error);
     }
@@ -420,6 +435,24 @@ export async function sendFirstDayMotivation(leagueId: string): Promise<void> {
 
         if (!league?.bonding_automations_enabled) {
             console.log('[Bonding] Automations disabled for league:', leagueId);
+            return;
+        }
+
+        // Idempotency guard: Check if first-day messages already sent today
+        const today = new Date().toISOString().split('T')[0];
+        const { data: existingMessages } = await supabase
+            .from('messages')
+            .select('message_id')
+            .eq('league_id', leagueId)
+            .eq('sender_id', league.created_by)
+            .eq('message_type', 'announcement')
+            .ilike('content', '%Day 1: Let\'s Do This!%')
+            .gte('created_at', `${today}T00:00:00.000Z`)
+            .lt('created_at', `${today}T23:59:59.999Z`)
+            .limit(1);
+
+        if (existingMessages && existingMessages.length > 0) {
+            console.log('[Bonding] First day motivation already sent today for league:', leagueId);
             return;
         }
 
@@ -453,3 +486,5 @@ export async function sendFirstDayMotivation(leagueId: string): Promise<void> {
         console.error('[Bonding] Error sending first day motivation:', error);
     }
 }
+ 
+ 

--- a/src/lib/services/bonding-automations.ts
+++ b/src/lib/services/bonding-automations.ts
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Bonding Automations Service - Automated team bonding messages and captain guidance
  * Handles welcome messages, member announcements, and team identity reveals
  */
@@ -33,23 +33,23 @@ export interface BondingMessageTemplate {
 // ============================================================================
 
 const BONDING_TEMPLATES: BondingMessageTemplate = {
-    welcome_new_member: `🎉 **Welcome to the team, {member_name}!**
+    welcome_new_member: `ðŸŽ‰ **Welcome to the team, {member_name}!**
 
 We're excited to have you join us! Here's what you need to know:
 
-• **Team Goal**: Work together to achieve our fitness targets
-• **Support**: Your teammates are here to motivate and encourage you
-• **Communication**: Use this chat to share progress, ask questions, and celebrate wins
+â€¢ **Team Goal**: Work together to achieve our fitness targets
+â€¢ **Support**: Your teammates are here to motivate and encourage you
+â€¢ **Communication**: Use this chat to share progress, ask questions, and celebrate wins
 
-Let's make this league amazing together! 💪`,
+Let's make this league amazing together! ðŸ’ª`,
 
-    team_announcement: `👋 **Team Update**
+    team_announcement: `ðŸ‘‹ **Team Update**
 
 {member_name} has joined our squad! Let's give them a warm welcome.
 
-Our team now has **{member_count} members** ready to crush this league together! 🔥`,
+Our team now has **{member_count} members** ready to crush this league together! ðŸ”¥`,
 
-    team_identity_reveal: `🏆 **Meet Your Team: {team_name}**
+    team_identity_reveal: `ðŸ† **Meet Your Team: {team_name}**
 
 Your team is officially formed and ready for action! Here's your squad:
 
@@ -59,54 +59,54 @@ Your team is officially formed and ready for action! Here's your squad:
 
 Time to bond, support each other, and show everyone what {team_name} can do! 
 
-Good luck, team! 🚀`,
+Good luck, team! ðŸš€`,
 
-    captain_guidance: `👑 **Captain Guidelines - Week 1 Focus**
+    captain_guidance: `ðŸ‘‘ **Captain Guidelines - Week 1 Focus**
 
 As team captain, here are your key responsibilities to build team spirit:
 
-**🤝 Team Bonding (Days 1-3)**
-• Welcome each new member personally
-• Share your fitness goals and encourage others to do the same
-• Create a positive, supportive team culture
+**ðŸ¤ Team Bonding (Days 1-3)**
+â€¢ Welcome each new member personally
+â€¢ Share your fitness goals and encourage others to do the same
+â€¢ Create a positive, supportive team culture
 
-**📋 Organization (Days 4-7)**
-• Help teammates understand league rules and scoring
-• Validate workout submissions promptly
-• Encourage consistent participation
+**ðŸ“‹ Organization (Days 4-7)**
+â€¢ Help teammates understand league rules and scoring
+â€¢ Validate workout submissions promptly
+â€¢ Encourage consistent participation
 
-**💬 Communication Tips**
-• Check in with quiet team members
-• Celebrate small wins and progress
-• Address any concerns quickly and positively
+**ðŸ’¬ Communication Tips**
+â€¢ Check in with quiet team members
+â€¢ Celebrate small wins and progress
+â€¢ Address any concerns quickly and positively
 
-Your leadership sets the tone for the entire team's experience! 🌟`,
+Your leadership sets the tone for the entire team's experience! ðŸŒŸ`,
 
-    captain_intro_prompt: `👑 **Captain, It's Time to Lead!**
+    captain_intro_prompt: `ðŸ‘‘ **Captain, It's Time to Lead!**
 
 Hey Captain! Your team is counting on you to set the tone. Here's your first mission:
 
 **Introduce yourself to your team!** Share:
-• Your fitness background or goals
-• What excites you about this league
-• How you'll support the team
+â€¢ Your fitness background or goals
+â€¢ What excites you about this league
+â€¢ How you'll support the team
 
-A strong start builds team energy and trust. Your teammates are waiting to hear from you! 💪
+A strong start builds team energy and trust. Your teammates are waiting to hear from you! ðŸ’ª
 
-Drop your intro message below 👇`,
+Drop your intro message below ðŸ‘‡`,
 
-    first_day_motivation: `🎯 **Day 1: Let's Do This!**
+    first_day_motivation: `ðŸŽ¯ **Day 1: Let's Do This!**
 
 Welcome to the first day of the league! This is where champions are made.
 
 **Today's Focus:**
-• Log your first workout and set the momentum
-• Connect with your teammates in the chat
-• Review the league rules and scoring system
+â€¢ Log your first workout and set the momentum
+â€¢ Connect with your teammates in the chat
+â€¢ Review the league rules and scoring system
 
 **Remember:** Every journey starts with a single step. Your team is here to support you, and together you'll achieve amazing things.
 
-Let's make today count! 🔥💪`
+Let's make today count! ðŸ”¥ðŸ’ª`
 };
 
 // ============================================================================
@@ -229,7 +229,7 @@ export async function sendTeamIdentityReveal(
 
         // Build member list
         const memberList = members
-            .map(m => `• ${m.username}${m.is_captain ? ' (Captain)' : ''}`)
+            .map(m => `â€¢ ${m.username}${m.is_captain ? ' (Captain)' : ''}`)
             .join('\n');
 
         const message = BONDING_TEMPLATES.team_identity_reveal
@@ -416,6 +416,78 @@ export async function sendCaptainIntroPrompts(leagueId: string): Promise<void> {
         console.log(`[Bonding] Captain intro prompts sent for ${teamsWithCaptains.length} teams with captains`);
     } catch (error) {
         console.error('[Bonding] Error sending captain intro prompts:', error);
+    }
+}
+
+/**
+ * Optimized function to send both team reveals and captain prompts with consolidated queries
+ */
+export async function sendLaunchBondingMessages(leagueId: string): Promise<void> {
+    try {
+        const supabase = getSupabaseServiceRole();
+
+        // Single query to get league settings and teams
+        const [leagueResult, teamsResult] = await Promise.all([
+            supabase
+                .from('leagues')
+                .select('bonding_automations_enabled, created_by')
+                .eq('league_id', leagueId)
+                .single(),
+            supabase
+                .from('teams')
+                .select('team_id')
+                .eq('league_id', leagueId)
+        ]);
+
+        const { data: league } = leagueResult;
+        const { data: teams } = teamsResult;
+
+        if (!league?.bonding_automations_enabled) {
+            console.log('[Bonding] Automations disabled for league:', leagueId);
+            return;
+        }
+
+        if (!teams || teams.length === 0) {
+            console.log('[Bonding] No teams found for league:', leagueId);
+            return;
+        }
+
+        // Get team members for all teams in parallel to check for captains
+        const teamMembersPromises = teams.map(team =>
+            getTeamMembers(team.team_id, leagueId).then(members => ({
+                teamId: team.team_id,
+                members,
+                hasCaptain: members.some(m => m.is_captain)
+            }))
+        );
+
+        const teamMembersData = await Promise.all(teamMembersPromises);
+
+        // Prepare messages
+        const identityRevealPromises = teams.map(team =>
+            sendTeamIdentityReveal(leagueId, team.team_id)
+        );
+
+        const teamsWithCaptains = teamMembersData
+            .filter(data => data.hasCaptain)
+            .map(data => data.teamId);
+
+        const captainIntroPromises = teamsWithCaptains.map(teamId =>
+            sendMessage(leagueId, league.created_by, {
+                content: BONDING_TEMPLATES.captain_intro_prompt,
+                teamId: teamId,
+                messageType: 'announcement',
+                visibility: 'captains_only',
+                isImportant: true,
+            })
+        );
+
+        // Send all messages in parallel
+        await Promise.all([...identityRevealPromises, ...captainIntroPromises]);
+
+        console.log(`[Bonding] Launch messages sent: ${teams.length} team reveals, ${teamsWithCaptains.length} captain prompts`);
+    } catch (error) {
+        console.error('[Bonding] Error sending launch bonding messages:', error);
     }
 }
 

--- a/src/lib/services/bonding-automations.ts
+++ b/src/lib/services/bonding-automations.ts
@@ -24,6 +24,8 @@ export interface BondingMessageTemplate {
     team_announcement: string;
     team_identity_reveal: string;
     captain_guidance: string;
+    captain_intro_prompt: string;
+    first_day_motivation: string;
 }
 
 // ============================================================================
@@ -78,7 +80,33 @@ As team captain, here are your key responsibilities to build team spirit:
 • Celebrate small wins and progress
 • Address any concerns quickly and positively
 
-Your leadership sets the tone for the entire team's experience! 🌟`
+Your leadership sets the tone for the entire team's experience! 🌟`,
+
+    captain_intro_prompt: `👑 **Captain, It's Time to Lead!**
+
+Hey Captain! Your team is counting on you to set the tone. Here's your first mission:
+
+**Introduce yourself to your team!** Share:
+• Your fitness background or goals
+• What excites you about this league
+• How you'll support the team
+
+A strong start builds team energy and trust. Your teammates are waiting to hear from you! 💪
+
+Drop your intro message below 👇`,
+
+    first_day_motivation: `🎯 **Day 1: Let's Do This!**
+
+Welcome to the first day of the league! This is where champions are made.
+
+**Today's Focus:**
+• Log your first workout and set the momentum
+• Connect with your teammates in the chat
+• Review the league rules and scoring system
+
+**Remember:** Every journey starts with a single step. Your team is here to support you, and together you'll achieve amazing things.
+
+Let's make today count! 🔥💪`
 };
 
 // ============================================================================
@@ -284,6 +312,18 @@ export async function sendAllTeamIdentityReveals(leagueId: string): Promise<void
     try {
         const supabase = getSupabaseServiceRole();
 
+        // Check if bonding automations are enabled
+        const { data: league } = await supabase
+            .from('leagues')
+            .select('bonding_automations_enabled')
+            .eq('league_id', leagueId)
+            .single();
+
+        if (!league?.bonding_automations_enabled) {
+            console.log('[Bonding] Automations disabled for league:', leagueId);
+            return;
+        }
+
         // Get all teams in the league
         const { data: teams } = await supabase
             .from('teams')
@@ -312,4 +352,104 @@ export async function sendAllTeamIdentityReveals(leagueId: string): Promise<void
  */
 export function getCaptainGuidelines(): string {
     return BONDING_TEMPLATES.captain_guidance;
+}
+
+/**
+ * Send captain intro prompt to all captains when league launches
+ */
+export async function sendCaptainIntroPrompts(leagueId: string): Promise<void> {
+    try {
+        const supabase = getSupabaseServiceRole();
+
+        // Check if bonding automations are enabled
+        const { data: league } = await supabase
+            .from('leagues')
+            .select('bonding_automations_enabled, created_by')
+            .eq('league_id', leagueId)
+            .single();
+
+        if (!league?.bonding_automations_enabled) {
+            console.log('[Bonding] Automations disabled for league:', leagueId);
+            return;
+        }
+
+        // Get all teams in the league
+        const { data: teams } = await supabase
+            .from('teams')
+            .select('team_id')
+            .eq('league_id', leagueId);
+
+        if (!teams || teams.length === 0) {
+            console.log('[Bonding] No teams found for league:', leagueId);
+            return;
+        }
+
+        const message = BONDING_TEMPLATES.captain_intro_prompt;
+
+        // Send intro prompt to each team (captains will see it)
+        const promises = teams.map(team =>
+            sendMessage(leagueId, league.created_by, {
+                content: message,
+                teamId: team.team_id,
+                messageType: 'announcement',
+                visibility: 'captains_only',
+                isImportant: true,
+            })
+        );
+
+        await Promise.all(promises);
+        console.log(`[Bonding] Captain intro prompts sent for ${teams.length} teams`);
+    } catch (error) {
+        console.error('[Bonding] Error sending captain intro prompts:', error);
+    }
+}
+
+/**
+ * Send first day motivation message to all teams
+ */
+export async function sendFirstDayMotivation(leagueId: string): Promise<void> {
+    try {
+        const supabase = getSupabaseServiceRole();
+
+        // Check if bonding automations are enabled
+        const { data: league } = await supabase
+            .from('leagues')
+            .select('bonding_automations_enabled, created_by')
+            .eq('league_id', leagueId)
+            .single();
+
+        if (!league?.bonding_automations_enabled) {
+            console.log('[Bonding] Automations disabled for league:', leagueId);
+            return;
+        }
+
+        // Get all teams in the league
+        const { data: teams } = await supabase
+            .from('teams')
+            .select('team_id')
+            .eq('league_id', leagueId);
+
+        if (!teams || teams.length === 0) {
+            console.log('[Bonding] No teams found for league:', leagueId);
+            return;
+        }
+
+        const message = BONDING_TEMPLATES.first_day_motivation;
+
+        // Send motivation message to each team
+        const promises = teams.map(team =>
+            sendMessage(leagueId, league.created_by, {
+                content: message,
+                teamId: team.team_id,
+                messageType: 'announcement',
+                visibility: 'all',
+                isImportant: true,
+            })
+        );
+
+        await Promise.all(promises);
+        console.log(`[Bonding] First day motivation sent for ${teams.length} teams`);
+    } catch (error) {
+        console.error('[Bonding] Error sending first day motivation:', error);
+    }
 }

--- a/src/lib/services/leagues.ts
+++ b/src/lib/services/leagues.ts
@@ -42,6 +42,7 @@ export interface League extends LeagueInput {
   modified_date: string;
   max_team_capacity?: number; // Configurable limit (default 10)
   league_capacity?: number; // Derived from tier
+  bonding_automations_enabled?: boolean; // Enable/disable automated team bonding messages
 }
 
 function mapDbLeagueToLeague(dbLeague: any): League {

--- a/supabase/migrations/20260420_bonding_automations_settings.sql
+++ b/supabase/migrations/20260420_bonding_automations_settings.sql
@@ -1,0 +1,6 @@
+-- Add bonding automation settings to leagues table
+-- Allows hosts to enable/disable automated team bonding messages
+
+ALTER TABLE leagues ADD COLUMN IF NOT EXISTS bonding_automations_enabled BOOLEAN DEFAULT true;
+
+COMMENT ON COLUMN leagues.bonding_automations_enabled IS 'When true, automated team bonding messages are sent at key lifecycle moments (team reveal, captain intro, first day)';

--- a/vercel.json
+++ b/vercel.json
@@ -23,6 +23,10 @@
     {
       "path": "/api/cron/ai-nudges",
       "schedule": "30 4 * * *"
+    },
+    {
+      "path": "/api/cron/first-day-motivation",
+      "schedule": "0 0 * * *"
     }
   ],
   "rewrites": [


### PR DESCRIPTION
## Summary

Extend Captain Guidelines (#153) with automated system messages that fire at key league lifecycle moments, team reveal on launch, captain intro prompt, and first-day motivation via daily cron.

## Related Issue

Closes #154

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no functional change)
- [ ] UI/UX improvement
- [ ] Chore (dependencies, config, CI)
- [ ] Documentation

## Changes Made

- Added `bonding_automations_enabled` field to leagues table (default: `true`) via migration `20260420_bonding_automations_settings.sql`
- Extended `bonding-automations.ts` with team reveal, captain intro prompt, and first-day motivation message functions
- Updated league launch route to trigger team reveal + captain intro prompt on launch
- Added daily cron job (`route.ts`) to send first-day motivation to all leagues starting that day
- Registered cron in `vercel.json`
- Updated `leagues.ts` interface with new field
- All calls are non-blocking async — messages never block API responses

## How to Test

1. Launch a league — verify team reveal message and captain intro prompt appear in all team chats
2. Check a league on its first day — verify motivational message is sent to all teams
3. Disable bonding automations on a league (host toggle) — verify no messages are sent on launch

## Screenshots / Recordings

<!-- Add screenshots of automated messages in team chat -->

## Checklist

- [x] I have tested this locally and it works
- [x] `pnpm build` passes with no errors
- [x] No `console.log` or commented-out code left behind
- [x] My branch is up to date with `develop`
- [x] I have not modified any files outside the scope of this task